### PR TITLE
fix: finding the associated token account address

### DIFF
--- a/src/actions/mintEditionFromMaster.ts
+++ b/src/actions/mintEditionFromMaster.ts
@@ -46,7 +46,7 @@ export const mintEditionFromMaster = async (
     TOKEN_PROGRAM_ID,
     masterEditionMint,
     wallet.publicKey,
-    true
+    true,
   );
 
   const metadataPDA = await Metadata.getPDA(mint.publicKey);

--- a/src/actions/mintEditionFromMaster.ts
+++ b/src/actions/mintEditionFromMaster.ts
@@ -46,6 +46,7 @@ export const mintEditionFromMaster = async (
     TOKEN_PROGRAM_ID,
     masterEditionMint,
     wallet.publicKey,
+    true
   );
 
   const metadataPDA = await Metadata.getPDA(mint.publicKey);

--- a/src/actions/shared/index.ts
+++ b/src/actions/shared/index.ts
@@ -23,6 +23,7 @@ export async function prepareTokenAccountAndMintTx(connection: Connection, owner
     TOKEN_PROGRAM_ID,
     mint.publicKey,
     owner,
+    true
   );
 
   const createAssociatedTokenAccountTx = new CreateAssociatedTokenAccount(

--- a/src/actions/shared/index.ts
+++ b/src/actions/shared/index.ts
@@ -23,7 +23,7 @@ export async function prepareTokenAccountAndMintTx(connection: Connection, owner
     TOKEN_PROGRAM_ID,
     mint.publicKey,
     owner,
-    true
+    true,
   );
 
   const createAssociatedTokenAccountTx = new CreateAssociatedTokenAccount(


### PR DESCRIPTION
fix: remove unnecessary restriction for finding the associated token account address

during minting/editionMinting process, allow owner off curve to get associated token address