### PR TITLE
chore: specify correct label to auto-apply

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 # https://github.com/marketplace/actions/labeler
 
-# Add 'SDK JS' label to all Pull Requests
-SDK JS:
+# Add 'SDK: JS' label to all Pull Requests
+'SDK: JS':
 - '**/*'


### PR DESCRIPTION
"SDK JS" is not a valid label.

"SDK: JS" is.

Relates to #97 