### PR TITLE
chore: switch to auto-labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'SDK: JS'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'SDK: JS'
 assignees: ''
 
 ---

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
-# https://github.com/marketplace/actions/labeler
+# https://github.com/marketplace/actions/auto-labeler
 
-# Add 'SDK: JS' label to all Pull Requests
-'SDK: JS':
-- '**/*'
+labels:
+  'SDK: JS':
+  - '.*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,12 +1,18 @@
-# https://github.com/marketplace/actions/labeler
-name: "Pull Request Labeler"
+# https://github.com/marketplace/actions/auto-labeler
+
+name: Issue and Pull Request labeler
 on:
-  pull_request_target
+  issues:
+    types: [opened, transferred, reopened]
+  pull_request_target:
+    types: [opened, reopened]
 
 jobs:
-  triage:
+  labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
+    - name: Check Labels
+      id: labeler
+      uses: jimschubert/labeler-action@v2
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This github action handles both Issues and Pull Requests in one place.

The current approach for labeling Issues did not support Issues created without using the Issue templates, for example, when creating them via Github Projects.