### PR TITLE
fix: add back Optional type import

### DIFF
--- a/src/actions/shared/approve.ts
+++ b/src/actions/shared/approve.ts
@@ -1,5 +1,6 @@
 import { Token, TOKEN_PROGRAM_ID, u64 } from '@solana/spl-token';
 import { Keypair, PublicKey, Transaction } from '@solana/web3.js';
+import { Optional } from '../../types';
 
 interface CreateApproveParams {
   authority: Keypair;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,5 @@ export type MetadataJson = {
   collection?: MetadataJsonCollection;
   properties: MetadataJsonProperties;
 };
+
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,1 +1,0 @@
-type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;


### PR DESCRIPTION
#138 removed the inclusive import of `./shared` preventing [Optional](https://github.com/metaplex-foundation/js/blob/main/src/typings/index.d.ts#L1) from getting imported properly, breaking external builds. See issue: https://github.com/metaplex-foundation/js/issues/139.

PR converges all types under `types.ts` and directly imports `Optional`. 

Tested that external builds work by manually importing the local forked npm package via `npm link` and building using `tsc`. 

fixes #139
