### PR TITLE
fix: allow Master Edition max supply to be 0

### DIFF
--- a/src/actions/mintNFT.ts
+++ b/src/actions/mintNFT.ts
@@ -14,14 +14,14 @@ import { sendTransaction } from './transactions';
 import { lookup } from '../utils/metadata';
 import { prepareTokenAccountAndMintTxs } from './shared';
 
-interface MintNFTParams {
+export interface MintNFTParams {
   connection: Connection;
   wallet: Wallet;
   uri: string;
   maxSupply?: number;
 }
 
-interface MintNFTResponse {
+export interface MintNFTResponse {
   txId: string;
   mint: PublicKey;
   metadata: PublicKey;
@@ -90,7 +90,7 @@ export const mintNFT = async ({
       updateAuthority: wallet.publicKey,
       mint: mint.publicKey,
       mintAuthority: wallet.publicKey,
-      maxSupply: maxSupply ? new BN(maxSupply) : null,
+      maxSupply: (maxSupply || maxSupply === 0) ? new BN(maxSupply) : null,
     },
   );
 

--- a/src/actions/mintNFT.ts
+++ b/src/actions/mintNFT.ts
@@ -90,7 +90,7 @@ export const mintNFT = async ({
       updateAuthority: wallet.publicKey,
       mint: mint.publicKey,
       mintAuthority: wallet.publicKey,
-      maxSupply: (maxSupply || maxSupply === 0) ? new BN(maxSupply) : null,
+      maxSupply: maxSupply || maxSupply === 0 ? new BN(maxSupply) : null,
     },
   );
 

--- a/test/actions/createMetadataAndME.test.ts
+++ b/test/actions/createMetadataAndME.test.ts
@@ -1,7 +1,7 @@
 import BN from 'bn.js';
 import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { Connection, NodeWallet } from '../../src';
-import { FEE_PAYER, NETWORK, pause } from '../utils';
+import { FEE_PAYER, NETWORK, sleep } from '../utils';
 import {
   Creator,
   MasterEdition,
@@ -51,7 +51,7 @@ describe('creatomg metadata and master edition PDAs', () => {
       metadataData,
     });
 
-    await pause(20000);
+    await sleep(20000);
 
     const metadata = await Metadata.getPDA(mint.publicKey);
     const metadataInfo = await Account.getInfo(connection, metadata);
@@ -66,7 +66,7 @@ describe('creatomg metadata and master edition PDAs', () => {
     });
 
     // had to increase to 25s, or it was failing
-    await pause(25000);
+    await sleep(25000);
 
     const edition = await MasterEdition.getPDA(mint.publicKey);
     const editionInfo = await Account.getInfo(connection, edition);

--- a/test/actions/mintEditionFromMaster.test.ts
+++ b/test/actions/mintEditionFromMaster.test.ts
@@ -1,6 +1,6 @@
 import { Connection, NodeWallet } from '../../src';
 import { mintNFT } from '../../src/actions';
-import { FEE_PAYER, NETWORK, pause } from '../utils';
+import { FEE_PAYER, NETWORK, sleep } from '../utils';
 import { MasterEdition, Metadata } from '@metaplex-foundation/mpl-token-metadata';
 import { mintEditionFromMaster } from '../../src/actions/mintEditionFromMaster';
 import { mockAxios200, uri } from './shared';
@@ -26,7 +26,7 @@ describe('minting a limited edition from master', () => {
 
     // unfortunately it takes some time for the master mint to propagate
     // empirically, I found anything below 20s to be unreliable
-    await pause(20000);
+    await sleep(20000);
 
     const editionMintResponse = await mintEditionFromMaster({
       connection,

--- a/test/actions/mintNFT.test.ts
+++ b/test/actions/mintNFT.test.ts
@@ -1,7 +1,7 @@
 import { Keypair } from '@solana/web3.js';
 import { Connection, NodeWallet } from '../../src';
 import { mintNFT, MintNFTParams } from '../../src/actions';
-import { pause } from '../utils';
+import { sleep } from '../utils';
 import { MasterEdition, Metadata } from '@metaplex-foundation/mpl-token-metadata';
 import { uri, generateConnectionAndWallet, mockAxios200, mockAxios404 } from './shared';
 import { airdrop } from '@metaplex-foundation/amman';
@@ -52,7 +52,7 @@ describe('minting an NFT', () => {
             edition,
           });
 
-          await pause(2000); // HACK
+          await sleep(2000); // HACK
 
           const metadataEdition = await Metadata.getEdition(connection, mint) as MasterEdition;
           expect(metadataEdition.data?.maxSupply?.toNumber()).toBe(maxSupply);

--- a/test/actions/mintNFT.test.ts
+++ b/test/actions/mintNFT.test.ts
@@ -54,12 +54,12 @@ describe('minting an NFT', () => {
 
           await sleep(2000); // HACK
 
-          const metadataEdition = await Metadata.getEdition(connection, mint) as MasterEdition;
+          const metadataEdition = (await Metadata.getEdition(connection, mint)) as MasterEdition;
           expect(metadataEdition.data?.maxSupply?.toNumber()).toBe(maxSupply);
         });
       });
     }
-  })
+  });
 
   describe('when metadata json not found', () => {
     beforeEach(() => {

--- a/test/actions/signMetadata.test.ts
+++ b/test/actions/signMetadata.test.ts
@@ -1,7 +1,7 @@
 import { Keypair } from '@solana/web3.js';
 import { Connection, NodeWallet } from '../../src';
 import { mintNFT } from '../../src/actions';
-import { FEE_PAYER, NETWORK, pause } from '../utils';
+import { FEE_PAYER, NETWORK, sleep } from '../utils';
 import { Metadata } from '@metaplex-foundation/mpl-token-metadata';
 import { signMetadata } from '../../src/actions/signMetadata';
 import { mockAxios200, uri } from './shared';
@@ -30,7 +30,7 @@ describe('signing metadata on a master edition', () => {
 
     // unfortunately it takes some time for the master mint to propagate
     // empirically, I found anything below 20s to be unreliable
-    await pause(20000);
+    await sleep(20000);
 
     // before signing
     const metadata = await Metadata.getPDA(masterMintResponse.mint);
@@ -45,7 +45,7 @@ describe('signing metadata on a master edition', () => {
       signer: secondSigner,
     });
 
-    await pause(20000);
+    await sleep(20000);
 
     //after signing
     info = await Account.getInfo(connection, metadata);

--- a/test/actions/updateMetadata.test.ts
+++ b/test/actions/updateMetadata.test.ts
@@ -1,7 +1,7 @@
 import { Keypair } from '@solana/web3.js';
 import { Connection, NodeWallet } from '../../src';
 import { mintNFT } from '../../src/actions';
-import { FEE_PAYER, NETWORK, pause } from '../utils';
+import { FEE_PAYER, NETWORK, sleep } from '../utils';
 import { Creator, Metadata, MetadataDataData } from '@metaplex-foundation/mpl-token-metadata';
 import { updateMetadata } from '../../src/actions/updateMetadata';
 import { mockAxios200, uri } from './shared';
@@ -44,7 +44,7 @@ describe('updating metadata on a master edition', () => {
 
     // unfortunately it takes some time for the master mint to propagate
     // empirically, I found anything below 20s to be unreliable
-    await pause(20000);
+    await sleep(20000);
 
     // before update
     const metadata = await Metadata.getPDA(masterMintResponse.mint);
@@ -63,7 +63,7 @@ describe('updating metadata on a master edition', () => {
       primarySaleHappened: true,
     });
 
-    await pause(20000);
+    await sleep(20000);
 
     //after update
     info = await Account.getInfo(connection, metadata);

--- a/test/actions/utility/closeVault.test.ts
+++ b/test/actions/utility/closeVault.test.ts
@@ -1,7 +1,7 @@
 import { NATIVE_MINT } from '@solana/spl-token';
 import { Vault, VaultState } from '@metaplex-foundation/mpl-token-vault';
 
-import { pause } from '../../utils';
+import { sleep } from '../../utils';
 import { generateConnectionAndWallet } from '../shared';
 import { closeVault, createVault, createExternalPriceAccount } from '../../../src/actions/utility';
 
@@ -19,7 +19,7 @@ describe('closing a Vault', () => {
         ...externalPriceAccountData,
       });
 
-      await pause(1000);
+      await sleep(1000);
 
       vault = await Vault.load(connection, vaultResponse.vault);
       expect(vault).toHaveProperty('data');
@@ -32,7 +32,7 @@ describe('closing a Vault', () => {
         priceMint: NATIVE_MINT,
       });
 
-      await pause(1000);
+      await sleep(1000);
 
       vault = await Vault.load(connection, vaultResponse.vault);
       expect(vault).toHaveProperty('data');

--- a/test/actions/utility/createVault.test.ts
+++ b/test/actions/utility/createVault.test.ts
@@ -1,6 +1,6 @@
 import { Vault, VaultState } from '@metaplex-foundation/mpl-token-vault';
 
-import { pause } from '../../utils';
+import { sleep } from '../../utils';
 import { createVault, createExternalPriceAccount } from '../../../src/actions/utility';
 import { generateConnectionAndWallet } from '../shared';
 
@@ -17,7 +17,7 @@ describe('creating a Vault', () => {
         ...externalPriceAccountData,
       });
 
-      await pause(1000);
+      await sleep(1000);
       const vault = await Vault.load(connection, vaultResponse.vault);
       expect(vault).toHaveProperty('data');
       expect(vault.data.state).toEqual(VaultState.Inactive);

--- a/test/actions/utility/initAuction.test.ts
+++ b/test/actions/utility/initAuction.test.ts
@@ -8,7 +8,7 @@ import {
   WinnerLimitType,
 } from '@metaplex-foundation/mpl-auction';
 
-import { pause } from '../../utils';
+import { sleep } from '../../utils';
 import { generateConnectionAndWallet } from '../shared';
 import { createExternalPriceAccount, createVault, initAuction } from '../../../src/actions/utility';
 
@@ -45,7 +45,7 @@ describe('initAuction action', () => {
       auctionSettings,
     });
 
-    await pause(1000);
+    await sleep(1000);
 
     const auctionInstance = await Auction.load(connection, auction);
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -111,12 +111,8 @@ export const projectRoot = path.resolve(__dirname, '..', '..');
 export const tmpTestDir = path.resolve(tmpdir(), 'test');
 
 export const serializeConfig = { verifySignatures: false, requireAllSignatures: false };
-export async function pause(ms: number) {
-  await new Promise((response) =>
-    setTimeout(() => {
-      response(0);
-    }, ms),
-  );
+export async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function getUserKeypairFromFile(keypairPath) {


### PR DESCRIPTION
Master Editions are [currently prevented](https://github.com/metaplex-foundation/js/compare/aheckmann/maxSupply?expand=1#diff-8bf2c8c0964d7eb0a7829251ea8cc0b2b89115edd877699fd978020e6c00a255L93) by the JS SDK from having a `maxSupply` of `0` due to a common error (zero is falsey) found in many JavaScript programs. 

This PR:

- fixes the bug
- adds tests proving the fix
- updates the mintNFT tests to use our localnet to improve speed
- renames the `pause` test helper to `sleep`, a name commonly used on various platforms for this functionality

Replaces #67 

cc @kespinola