### PR TITLE
Fix instruction order in placeBid

### DIFF
--- a/src/actions/placeBid.ts
+++ b/src/actions/placeBid.ts
@@ -105,7 +105,6 @@ export const placeBid = async ({
     closeTokenAccountTx,
   } = await createWrappedAccountTxs(connection, bidder, amount.toNumber() + accountRentExempt * 2);
   txBatch.addTransaction(createTokenAccountTx);
-  txBatch.addAfterTransaction(closeTokenAccountTx);
   txBatch.addSigner(payingAccount);
   ////
 
@@ -123,6 +122,9 @@ export const placeBid = async ({
   txBatch.addAfterTransaction(createRevokeTx);
   txBatch.addSigner(transferAuthority);
   ////
+  
+  // token account must be closed after the revoke instruction
+  txBatch.addAfterTransaction(closeTokenAccountTx);
 
   // create place bid transaction
   const placeBidTransaction = new PlaceBid(


### PR DESCRIPTION
The revoke instruction for the transfer approval is sent after the transfer account is already closed. This reverses that order.