### PR TITLE
Fix issue with not being able to set max supply to 0

### DIFF
--- a/src/actions/mintNFT.ts
+++ b/src/actions/mintNFT.ts
@@ -94,7 +94,7 @@ export const mintNFT = async ({
       updateAuthority: wallet.publicKey,
       mint: mint.publicKey,
       mintAuthority: wallet.publicKey,
-      maxSupply: maxSupply || maxSupply === 0 ? new BN(maxSupply) : null,
+      maxSupply: maxSupply || maxSupply >= 0 ? new BN(maxSupply) : null,
     },
   );
 


### PR DESCRIPTION
It looks like you are unable to set max supply to 0. Which causes problems if you want to deliver a Master Edition that someone cannot create new items from.