### PR TITLE
ft(export-unsigned-transaction): Export instructions to merge into bigger transaction

### DIFF
--- a/src/actions/utility/createExternalPriceAccount.ts
+++ b/src/actions/utility/createExternalPriceAccount.ts
@@ -77,15 +77,15 @@ export const createExternalPriceAccount = async ({
     externalPriceAccountData,
   });
   txBatch.addTransaction(updateEPA);
+
   const externalPriceAccountResponse = {
     externalPriceAccount: externalPriceAccount.publicKey,
     priceMint: NATIVE_MINT,
+    transactionBatch: [txBatch]
   } as CreateExternalPriceAccountResponse
 
   if (isUninitialized) {
-    return Object.assign(externalPriceAccountResponse, {
-      transactionBatch: [txBatch]
-    } as CreateExternalPriceAccountResponse)
+    return externalPriceAccountResponse
   }
 
   const txId = await sendTransaction({
@@ -97,7 +97,6 @@ export const createExternalPriceAccount = async ({
 
   return {
     txId,
-    externalPriceAccount: externalPriceAccount.publicKey,
-    priceMint: NATIVE_MINT,
+    ...externalPriceAccountResponse,
   };
 };


### PR DESCRIPTION
Problem: As I can see from your metaplex web, when we take an action like selling NFT, we need to sign only one times to process createVault, addTokensToVault, activeVault, ... Our code may go out-of-date if not use from npm

Solution: Should we return a transactionBatch to use in a bigger transaction (sign one times) instead of calling these actions (actions.createExternalPriceAccount, actions.createVault...) and request users to approve for each transaction