### PR TITLE
chore: add bn.js types

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@metaplex-foundation/amman": "^0.1.0",
     "@ovos-media/ts-transform-paths": "^1.7.18-1",
+    "@types/bn.js": "^5.1.0",
     "@types/mime": "^2.0.3",
     "@types/sinon": "^10.0.11",
     "@types/tape": "^4.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,6 +1615,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bn.js@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/bs58@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.1.tgz#3d51222aab067786d3bc3740a84a7f5a0effaa37"


### PR DESCRIPTION
Explicitly install the 5.x version of types of bn.js for the sdk to fix the below.

Newest bn.js includes types, but dependencies of the sdk depend on an older version and end up
installing types for 4.x.

This causes dependents of the sdk to break if they use 5.x of bn.js
