### PR TITLE
fix: don't rely on explicit export of TransactionCtorFields type

### DIFF
--- a/src/actions/utility/createExternalPriceAccount.ts
+++ b/src/actions/utility/createExternalPriceAccount.ts
@@ -5,13 +5,7 @@ import {
   VaultProgram,
   UpdateExternalPriceAccount,
 } from '@metaplex-foundation/mpl-token-vault';
-import {
-  Keypair,
-  PublicKey,
-  SystemProgram,
-  TransactionCtorFields,
-  TransactionSignature,
-} from '@solana/web3.js';
+import { Keypair, PublicKey, SystemProgram, TransactionSignature } from '@solana/web3.js';
 import { NATIVE_MINT } from '@solana/spl-token';
 import { Transaction } from '@metaplex-foundation/mpl-core';
 
@@ -37,7 +31,7 @@ export const createExternalPriceAccount = async ({
   wallet,
 }: CreateExternalPriceAccountParams): Promise<CreateExternalPriceAccountResponse> => {
   const txBatch = new TransactionsBatch({ transactions: [] });
-  const txOptions: TransactionCtorFields = { feePayer: wallet.publicKey };
+  const txOptions: ConstructorParameters<typeof Transaction>[0] = { feePayer: wallet.publicKey };
 
   const epaRentExempt = await connection.getMinimumBalanceForRentExemption(
     Vault.MAX_EXTERNAL_ACCOUNT_SIZE,

--- a/src/transactions/CreateAssociatedTokenAccount.ts
+++ b/src/transactions/CreateAssociatedTokenAccount.ts
@@ -4,7 +4,6 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  TransactionCtorFields,
   TransactionInstruction,
 } from '@solana/web3.js';
 import { Buffer } from 'buffer';
@@ -16,7 +15,10 @@ type CreateAssociatedTokenAccountParams = {
 };
 
 export class CreateAssociatedTokenAccount extends Transaction {
-  constructor(options: TransactionCtorFields, params: CreateAssociatedTokenAccountParams) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: CreateAssociatedTokenAccountParams,
+  ) {
     const { feePayer } = options;
     const { associatedTokenAddress, walletAddress, splTokenMintAddress } = params;
     super(options);

--- a/src/transactions/CreateMint.ts
+++ b/src/transactions/CreateMint.ts
@@ -1,6 +1,6 @@
 import { Transaction } from '@metaplex-foundation/mpl-core';
 import { MintLayout, Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import { PublicKey, SystemProgram, TransactionCtorFields } from '@solana/web3.js';
+import { PublicKey, SystemProgram } from '@solana/web3.js';
 
 type CreateMintParams = {
   newAccountPubkey: PublicKey;
@@ -11,7 +11,7 @@ type CreateMintParams = {
 };
 
 export class CreateMint extends Transaction {
-  constructor(options: TransactionCtorFields, params: CreateMintParams) {
+  constructor(options: ConstructorParameters<typeof Transaction>[0], params: CreateMintParams) {
     const { feePayer } = options;
     const { newAccountPubkey, lamports, decimals, owner, freezeAuthority } = params;
 

--- a/src/transactions/CreateTokenAccount.ts
+++ b/src/transactions/CreateTokenAccount.ts
@@ -1,6 +1,6 @@
 import { Transaction } from '@metaplex-foundation/mpl-core';
 import { AccountLayout, Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import { PublicKey, SystemProgram, TransactionCtorFields } from '@solana/web3.js';
+import { PublicKey, SystemProgram } from '@solana/web3.js';
 
 type CreateTokenAccountParams = {
   newAccountPubkey: PublicKey;
@@ -10,7 +10,10 @@ type CreateTokenAccountParams = {
 };
 
 export class CreateTokenAccount extends Transaction {
-  constructor(options: TransactionCtorFields, params: CreateTokenAccountParams) {
+  constructor(
+    options: ConstructorParameters<typeof Transaction>[0],
+    params: CreateTokenAccountParams,
+  ) {
     const { feePayer } = options;
     const { newAccountPubkey, lamports, mint, owner } = params;
 

--- a/src/transactions/MintTo.ts
+++ b/src/transactions/MintTo.ts
@@ -1,5 +1,5 @@
 import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import { PublicKey, TransactionCtorFields } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
 import { Transaction } from '@metaplex-foundation/mpl-core';
 
@@ -11,7 +11,7 @@ type MintToParams = {
 };
 
 export class MintTo extends Transaction {
-  constructor(options: TransactionCtorFields, params: MintToParams) {
+  constructor(options: ConstructorParameters<typeof Transaction>[0], params: MintToParams) {
     const { feePayer } = options;
     const { mint, dest, authority, amount } = params;
 

--- a/src/transactions/PayForFiles.ts
+++ b/src/transactions/PayForFiles.ts
@@ -1,10 +1,5 @@
 import { Transaction } from '@metaplex-foundation/mpl-core';
-import {
-  PublicKey,
-  SystemProgram,
-  TransactionCtorFields,
-  TransactionInstruction,
-} from '@solana/web3.js';
+import { PublicKey, SystemProgram, TransactionInstruction } from '@solana/web3.js';
 import { config } from '@metaplex-foundation/mpl-core';
 import { Buffer } from 'buffer';
 
@@ -15,7 +10,7 @@ type PayForFilesParams = {
 };
 
 export class PayForFiles extends Transaction {
-  constructor(options: TransactionCtorFields, params: PayForFilesParams) {
+  constructor(options: ConstructorParameters<typeof Transaction>[0], params: PayForFilesParams) {
     const { feePayer } = options;
     const { lamports, fileHashes, arweaveWallet } = params;
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Keypair, PublicKey, TransactionCtorFields } from '@solana/web3.js';
+import { Keypair, PublicKey, Transaction } from '@solana/web3.js';
 import { tmpdir } from 'os';
 import { readFileSync } from 'fs';
 
@@ -88,7 +88,7 @@ export const VAULT_EXTENRNAL_PRICE_ACCOUNT = new PublicKey(
   '58S2MNcuS79ncBc5xi1T8jdS98jcXJbXqM5UvGvgmwcr',
 );
 
-export const mockTransaction: TransactionCtorFields = {
+export const mockTransaction: ConstructorParameters<typeof Transaction>[0] = {
   feePayer: new PublicKey('7J6QvJGCB22vDvYB33ikrWCXRBRsFY74ntAArSK4KJUn'),
   recentBlockhash: RECENT_ISH_BLOCKHASH,
 };


### PR DESCRIPTION
This is our bad. We:

1. Over-export fundamentally private types from @solana/web3.js _just_ so that TypeDoc can generate documentation for them. This has to stop.
2. Didn't stop to think that someone might have imported those types for use.

In this PR I replace the recently-renamed `TransactionCtorFields` type with a type that _derives_ it, for all current and future versions of web3.js. This will not break again, no matter how many times the parameter gets renamed.

Fixes #202.