### PR TITLE
Add inputs to tasks

### DIFF
--- a/src/utils/Task.ts
+++ b/src/utils/Task.ts
@@ -24,7 +24,7 @@ export type TaskOptions = {
 
 export class Task<T, I extends any[] = []> {
   protected callback: TaskCallback<T, I>;
-  protected children: Task<any>[];
+  protected children: Task<any, any[]>[];
   protected context: object;
   protected status: TaskStatus = 'pending';
   protected result: T | undefined = undefined;
@@ -33,7 +33,7 @@ export class Task<T, I extends any[] = []> {
 
   constructor(
     callback: TaskCallback<T, I>,
-    children: Task<any>[] = [],
+    children: Task<any, any[]>[] = [],
     context: object = {}
   ) {
     this.callback = callback;
@@ -113,17 +113,17 @@ export class Task<T, I extends any[] = []> {
     return this;
   }
 
-  setChildren(children: Task<any>[]) {
+  setChildren(children: Task<any, any[]>[]) {
     this.children = children;
 
     return this;
   }
 
-  getChildren(): Task<any>[] {
+  getChildren(): Task<any, any[]>[] {
     return this.children;
   }
 
-  getDescendants(): Task<any>[] {
+  getDescendants(): Task<any, any[]>[] {
     return this.children.flatMap((child) => [child, ...child.getDescendants()]);
   }
 

--- a/test/utils/Task.test.ts
+++ b/test/utils/Task.test.ts
@@ -307,7 +307,7 @@ test('[Task] it can require input parameters', async (t: Test) => {
   t.equal(result, 22);
 });
 
-test.only('[Task] nested tasks can depend on each other via input parameters', async (t: Test) => {
+test('[Task] nested tasks can depend on each other via input parameters', async (t: Test) => {
   // Given two child tasks:
   // - One that takes a text and returns its length.
   // - One that takes a number and returns its power.

--- a/test/utils/Task.test.ts
+++ b/test/utils/Task.test.ts
@@ -181,7 +181,6 @@ test('[Task] it can have nested tasks', async (t: Test) => {
   // Given simple child tasks that return numbers.
   const childA = new Task(() => 1);
   const childB = new Task(() => 2);
-  // childA.run('foo', {});
 
   // When we create a parent task that use these child tasks
   const parent = new Task(

--- a/test/utils/Task.test.ts
+++ b/test/utils/Task.test.ts
@@ -181,6 +181,7 @@ test('[Task] it can have nested tasks', async (t: Test) => {
   // Given simple child tasks that return numbers.
   const childA = new Task(() => 1);
   const childB = new Task(() => 2);
+  // childA.run('foo', {});
 
   // When we create a parent task that use these child tasks
   const parent = new Task(

--- a/test/utils/Task.test.ts
+++ b/test/utils/Task.test.ts
@@ -291,3 +291,43 @@ test('[Task] it be used to execute tasks in parallel', async (t: Test) => {
     { name: 'Child A', status: 'successful' },
   ]);
 });
+
+test('[Task] it can require input parameters', async (t: Test) => {
+  // Given task that accepts a text and a multiplier as inputs
+  // and returns the length of the text multiplied by the multiplier.
+  const task = new Task((scope, text: string, multiplier: number) => {
+    return text.length * multiplier;
+  });
+
+  // When we run that task by giving it the right inputs.
+  const result = await task.run({}, 'Hello World', 2);
+
+  // Then the task was successful and returned the right result.
+  t.equal(task.getStatus(), 'successful');
+  t.equal(result, 22);
+});
+
+test.only('[Task] nested tasks can depend on each other via input parameters', async (t: Test) => {
+  // Given two child tasks:
+  // - One that takes a text and returns its length.
+  // - One that takes a number and returns its power.
+  const childA = new Task((scope, text: string) => text.length);
+  const childB = new Task((scope, value: number) => value * value);
+
+  // And a parent task that composes the two child tasks.
+  const parent = new Task(
+    async (options) => {
+      const resultA = await childA.run(options, 'Hello World');
+      const resultB = await childB.run(options, resultA);
+      return resultB;
+    },
+    [childA, childB]
+  );
+
+  // When we run that parent task.
+  const result = await parent.run();
+
+  // Then the parent task was successful and returned the right result.
+  t.equal(parent.getStatus(), 'successful');
+  t.equal(result, 121);
+});


### PR DESCRIPTION
This PR enables nested Tasks to be composed within parents' Tasks by allowing them to accept an array of input.

Here's an example.


```ts
// Given two child tasks:
// - One that takes a text and returns its length.
// - One that takes a number and returns its power.
const childA = new Task((scope, text: string) => text.length);
const childB = new Task((scope, value: number) => value * value);

// And a parent task that composes the two child tasks.
const parent = new Task(
  async (options) => {
    const resultA = await childA.run(options, 'Hello World');
    const resultB = await childB.run(options, resultA);
    return resultB;
  },
  [childA, childB]
);

// When we run that parent task.
const result = await parent.run();

// Then the parent task was successful and returned the right result.
t.equal(parent.getStatus(), 'successful');
t.equal(result, 121);
```