### PR TITLE
Delete Array property to array.splice

### DIFF
--- a/src/types/Signer.ts
+++ b/src/types/Signer.ts
@@ -50,8 +50,8 @@ export const getSignerHistogram = (signers: Signer[]) =>
         const duplicateIdentitiesIndex = signers.identities.findIndex(
           ({ publicKey }) => publicKey.equals(signer.publicKey)
         );
-        delete signers.all[duplicateIndex];
-        delete signers.identities[duplicateIdentitiesIndex];
+        signers.all.splice(duplicateIndex, 1);
+        signers.identities.splice(duplicateIdentitiesIndex, 1);
         signers.all.push(signer);
         signers.keypairs.push(signer);
       }


### PR DESCRIPTION
 getSignerHistogram function has a problem with duplicate remove logic.
So I see a Signer.ts file that change the code

- older
```Typescript
53 --- delete signers.all[duplicateIndex]
54 --- delete signers.identities[duplicateIdentitiesIndex]
```

- newer
```Typescript
53 --- signers.all.splice(duplicateIndex, 1);
54 --- signers.identities.splice(duplicateIdentitiesIndex, 1);
```