### PR TITLE
aws tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,13 @@ To set this up, you need to pass in the AWS client as well as the bucket name yo
 import { awsStorage } from "@metaplex-foundation/js";
 import { S3Client } from "@aws-sdk/client-s3";
 
-const awsClient = new S3Client({ region: 'us-east-1' });
+const awsClient = new S3Client({
+    region: "us-east-1",
+    credentials: {
+      accessKeyId: "",
+      secretAccessKey: "",
+    },
+  });
 
 metaplex.use(awsStorage(awsClient, 'my-nft-bucket'));
 ```

--- a/src/plugins/awsStorage/AwsStorageDriver.ts
+++ b/src/plugins/awsStorage/AwsStorageDriver.ts
@@ -20,6 +20,7 @@ export class AwsStorageDriver implements StorageDriver {
       Bucket: this.bucketName,
       Key: file.uniqueName,
       Body: file.buffer,
+      ContentType: file.contentType
     });
 
     try {

--- a/src/plugins/awsStorage/AwsStorageDriver.ts
+++ b/src/plugins/awsStorage/AwsStorageDriver.ts
@@ -20,7 +20,7 @@ export class AwsStorageDriver implements StorageDriver {
       Bucket: this.bucketName,
       Key: file.uniqueName,
       Body: file.buffer,
-      ContentType: file.contentType,
+      ContentType: file.contentType || undefined,
     });
 
     try {

--- a/src/plugins/awsStorage/AwsStorageDriver.ts
+++ b/src/plugins/awsStorage/AwsStorageDriver.ts
@@ -20,7 +20,7 @@ export class AwsStorageDriver implements StorageDriver {
       Bucket: this.bucketName,
       Key: file.uniqueName,
       Body: file.buffer,
-      ContentType: file.contentType
+      ContentType: file.contentType,
     });
 
     try {


### PR DESCRIPTION
@lorisleiva , Good evening.

Tiny adjustment requests regarding AWS

- in the readme, display how to add the credentials as the buckets should be access controlled.
- include `contentType` as it's available in `MetaplexFile` anyway. This is a bit critical as without that parameter, S3 objects will default to downloading instead of displaying in browser.  Examples: [with contentType](https://s3.us-east-1.amazonaws.com/supermassiv/cEh6I4uGGJaLWR8S9IgE) / [without contentType](https://s3.us-east-1.amazonaws.com/supermassiv/3MmDfx4hB1I0g9WLavO6)