### PR TITLE
Add support for "using NFTs"

### DIFF
--- a/src/plugins/nftModule/NftClient.ts
+++ b/src/plugins/nftModule/NftClient.ts
@@ -27,6 +27,7 @@ import {
   PrintNewEditionSharedInput,
   PrintNewEditionViaInput,
 } from './printNewEdition';
+import { UseNftInput, useNftOperation, UseNftOutput } from './useNft';
 
 export class NftClient {
   constructor(protected readonly metaplex: Metaplex) {}
@@ -83,10 +84,15 @@ export class NftClient {
     return { ...updateNftOutput, nft: updatedNft };
   }
 
-  async use(nft: Nft, uses?: number): Promise<{ nft: Nft }> {
-    console.log('using nft', nft.mint.toString());
-    nft.uses;
-    return { nft };
+  async use(
+    nft: Nft,
+    input?: Omit<UseNftInput, 'nft'>
+  ): Promise<{ nft: Nft } & UseNftOutput> {
+    const operation = useNftOperation({ ...input, nft });
+    const useNftOutput = await this.metaplex.operations().execute(operation);
+    const updatedNft = await this.findByMint(nft.mint);
+
+    return { ...useNftOutput, nft: updatedNft };
   }
 
   async printNewEdition(

--- a/src/plugins/nftModule/NftClient.ts
+++ b/src/plugins/nftModule/NftClient.ts
@@ -83,6 +83,12 @@ export class NftClient {
     return { ...updateNftOutput, nft: updatedNft };
   }
 
+  async use(nft: Nft, uses?: number): Promise<{ nft: Nft }> {
+    console.log('using nft', nft.mint.toString());
+    nft.uses;
+    return { nft };
+  }
+
   async printNewEdition(
     originalMint: PublicKey,
     input: Omit<PrintNewEditionSharedInput, 'originalMint'> &

--- a/src/plugins/nftModule/plugin.ts
+++ b/src/plugins/nftModule/plugin.ts
@@ -31,6 +31,7 @@ import {
   uploadMetadataOperation,
   uploadMetadataOperationHandler,
 } from './uploadMetadata';
+import { useNftOperation, useNftOperationHandler } from './useNft';
 
 export const nftModule = (): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
@@ -56,6 +57,7 @@ export const nftModule = (): MetaplexPlugin => ({
     op.register(printNewEditionOperation, printNewEditionOperationHandler);
     op.register(updateNftOperation, updateNftOperationHandler);
     op.register(uploadMetadataOperation, uploadMetadataOperationHandler);
+    op.register(useNftOperation, useNftOperationHandler);
 
     metaplex.nfts = function () {
       return new NftClient(this);

--- a/src/plugins/nftModule/useNft.ts
+++ b/src/plugins/nftModule/useNft.ts
@@ -23,6 +23,9 @@ export interface UseNftInput {
   // Signers.
   useAuthority?: Signer;
 
+  // Public Keys.
+  owner?: PublicKey;
+
   // Options.
   confirmOptions?: ConfirmOptions;
 }
@@ -41,21 +44,15 @@ export const useNftOperationHandler: OperationHandler<UseNftOperation> = {
       numberOfUses = 1,
       useAuthority = metaplex.identity(),
       confirmOptions,
+      owner = useAuthority.publicKey,
     } = operation.input;
 
-    // something is wrong here...
-    const owner = nft.metadataAccount.owner;
     const metadata = findMetadataPda(nft.mint);
     const tokenAccount = findAssociatedTokenAccountPda(nft.mint, owner);
 
-    console.log({
-      useAuthority: useAuthority.publicKey.toString(),
-      owner: owner.toString(),
-    });
-
     const accounts: UtilizeInstructionAccounts = {
       mint: nft.mint,
-      useAuthority: owner,
+      useAuthority: useAuthority.publicKey,
       owner,
       tokenAccount,
       metadata,

--- a/src/plugins/nftModule/useNft.ts
+++ b/src/plugins/nftModule/useNft.ts
@@ -1,0 +1,115 @@
+import { ConfirmOptions, PublicKey } from '@solana/web3.js';
+import { useOperation, Operation, Signer, OperationHandler } from '@/types';
+import { Nft } from './Nft';
+import { Metaplex } from '@/Metaplex';
+import {
+  createUtilizeInstructionWithSigners,
+  findMetadataPda,
+} from '@/programs';
+import { TransactionBuilder } from '@/utils';
+import { UtilizeInstructionAccounts } from '@metaplex-foundation/mpl-token-metadata';
+
+const Key = 'UseNftOperation' as const;
+export const useNftOperation = useOperation<UseNftOperation>(Key);
+export type UseNftOperation = Operation<typeof Key, UseNftInput, UseNftOutput>;
+
+export interface UseNftInput {
+  nft: Nft;
+
+  // Data.
+  numberOfUses?: number;
+
+  // Signers.
+  updateAuthority?: Signer;
+
+  // Options.
+  confirmOptions?: ConfirmOptions;
+}
+
+export interface UseNftOutput {
+  transactionId: string;
+}
+
+export const useNftOperationHandler: OperationHandler<UseNftOperation> = {
+  handle: async (
+    operation: UseNftOperation,
+    metaplex: Metaplex
+  ): Promise<UseNftOutput> => {
+    const {
+      nft,
+      numberOfUses = 1,
+      updateAuthority = metaplex.identity(),
+      confirmOptions,
+    } = operation.input;
+
+    // something is wrong here...
+    const metadata = findMetadataPda(nft.mint);
+
+    const accounts: UtilizeInstructionAccounts = {
+      mint: nft.mint,
+      owner: nft.metadataAccount.owner,
+      useAuthority: nft.updateAuthority,
+      tokenAccount: nft.mint,
+      metadata,
+    };
+
+    const transaction = useNftBuilder({
+      ...accounts,
+      numberOfUses,
+      updateAuthority,
+      metadata: nft.metadataAccount.publicKey,
+    });
+
+    const { signature } = await metaplex
+      .rpc()
+      .sendAndConfirmTransaction(transaction, undefined, confirmOptions);
+
+    return { transactionId: signature };
+  },
+};
+
+export interface UseNftBuilderParams {
+  // Data.
+  numberOfUses: number;
+
+  // Signers.
+  updateAuthority: Signer;
+
+  // Public keys.
+  metadata: PublicKey;
+  tokenAccount: PublicKey;
+  mint: PublicKey;
+  useAuthority: PublicKey;
+  owner: PublicKey;
+
+  // Instruction keys.
+  instructionKey?: string;
+}
+
+export const useNftBuilder = (
+  params: UseNftBuilderParams
+): TransactionBuilder => {
+  const {
+    numberOfUses,
+    updateAuthority,
+    metadata,
+    instructionKey,
+    tokenAccount,
+    mint,
+    useAuthority,
+    owner,
+  } = params;
+
+  return TransactionBuilder.make().add(
+    createUtilizeInstructionWithSigners({
+      numberOfUses,
+      metadata,
+      updateAuthority,
+      tokenAccount,
+      mint,
+      useAuthority,
+      owner,
+      instructionKey,
+    })
+  );
+};

--- a/src/programs/tokenMetadata/instructions/createUtilizeInstructionWithSigners.ts
+++ b/src/programs/tokenMetadata/instructions/createUtilizeInstructionWithSigners.ts
@@ -11,9 +11,8 @@ export interface CreateUtilizeInstructionWithSignersParams {
   metadata: PublicKey;
   tokenAccount: PublicKey;
   mint: PublicKey;
-  useAuthority: PublicKey;
+  useAuthority: Signer;
   owner: PublicKey;
-  updateAuthority: Signer;
   useAuthorityRecord?: PublicKey | undefined;
   burner?: PublicKey | undefined;
   instructionKey?: string;
@@ -31,14 +30,13 @@ export const createUtilizeInstructionWithSigners = (
     useAuthority,
     useAuthorityRecord,
     burner,
-    updateAuthority,
     instructionKey = 'utilize',
   } = params;
 
   const accounts: UtilizeInstructionAccounts = {
     metadata,
     tokenAccount,
-    useAuthority,
+    useAuthority: useAuthority.publicKey,
     mint,
     owner,
     useAuthorityRecord,
@@ -51,7 +49,7 @@ export const createUtilizeInstructionWithSigners = (
         numberOfUses,
       },
     }),
-    signers: [updateAuthority],
+    signers: [useAuthority],
     key: instructionKey,
   };
 };

--- a/src/programs/tokenMetadata/instructions/createUtilizeInstructionWithSigners.ts
+++ b/src/programs/tokenMetadata/instructions/createUtilizeInstructionWithSigners.ts
@@ -1,0 +1,57 @@
+import { PublicKey } from '@solana/web3.js';
+import {
+  createUtilizeInstruction,
+  UtilizeInstructionAccounts,
+} from '@metaplex-foundation/mpl-token-metadata';
+import { Signer } from '@/types';
+import { InstructionWithSigners } from '@/utils';
+
+export interface CreateUtilizeInstructionWithSignersParams {
+  numberOfUses: number;
+  metadata: PublicKey;
+  tokenAccount: PublicKey;
+  mint: PublicKey;
+  useAuthority: PublicKey;
+  owner: PublicKey;
+  updateAuthority: Signer;
+  useAuthorityRecord?: PublicKey | undefined;
+  burner?: PublicKey | undefined;
+  instructionKey?: string;
+}
+
+export const createUtilizeInstructionWithSigners = (
+  params: CreateUtilizeInstructionWithSignersParams
+): InstructionWithSigners => {
+  const {
+    numberOfUses,
+    metadata,
+    tokenAccount,
+    mint,
+    owner,
+    useAuthority,
+    useAuthorityRecord,
+    burner,
+    updateAuthority,
+    instructionKey = 'utilize',
+  } = params;
+
+  const accounts: UtilizeInstructionAccounts = {
+    metadata,
+    tokenAccount,
+    useAuthority,
+    mint,
+    owner,
+    useAuthorityRecord,
+    burner,
+  };
+
+  return {
+    instruction: createUtilizeInstruction(accounts, {
+      utilizeArgs: {
+        numberOfUses,
+      },
+    }),
+    signers: [updateAuthority],
+    key: instructionKey,
+  };
+};

--- a/src/programs/tokenMetadata/instructions/index.ts
+++ b/src/programs/tokenMetadata/instructions/index.ts
@@ -3,3 +3,4 @@ export * from './createCreateMetadataAccountV2InstructionWithSigners';
 export * from './createMintNewEditionFromMasterEditionViaTokenInstructionWithSigners';
 export * from './createMintNewEditionFromMasterEditionViaVaultProxyInstructionWithSigners';
 export * from './createUpdateMetadataAccountV2InstructionWithSigners';
+export * from './createUtilizeInstructionWithSigners';

--- a/test/plugins/nftModule/useNft.test.ts
+++ b/test/plugins/nftModule/useNft.test.ts
@@ -59,54 +59,54 @@ test('it can use an nft', async (t: Test) => {
   } as unknown as Specifications<Nft>);
 });
 
-// test('it can use an nft multiple times', async (t: Test) => {
-//   const totalUses = 10;
-//   const timesToUse = 3;
-//   // Given we have a Metaplex instance.
-//   const mx = await metaplex();
+test('it can use an nft multiple times', async (t: Test) => {
+  const totalUses = 10;
+  const timesToUse = 3;
+  // Given we have a Metaplex instance.
+  const mx = await metaplex();
 
-//   // And an existing SFT.
-//   const nft = await createNft(
-//     mx,
-//     {
-//       name: 'JSON SFT name',
-//       description: 'JSON SFT description',
-//       image: useMetaplexFile('some image', 'some-image.jpg'),
-//     },
-//     {
-//       name: 'On-chain SFT name',
-//       isMutable: true,
-//       uses: {
-//         useMethod: 1,
-//         remaining: totalUses,
-//         total: totalUses,
-//       },
-//     }
-//   );
+  // And an existing SFT.
+  const nft = await createNft(
+    mx,
+    {
+      name: 'JSON SFT name',
+      description: 'JSON SFT description',
+      image: useMetaplexFile('some image', 'some-image.jpg'),
+    },
+    {
+      name: 'On-chain SFT name',
+      isMutable: true,
+      uses: {
+        useMethod: 1,
+        remaining: totalUses,
+        total: totalUses,
+      },
+    }
+  );
 
-//   // When we use the NFT "n" times.
-//   const { nft: usedNft } = await mx
-//     .nfts()
-//     .use(nft, { numberOfUses: timesToUse });
+  // When we use the NFT "n" times.
+  const { nft: usedNft } = await mx
+    .nfts()
+    .use(nft, { numberOfUses: timesToUse });
 
-//   // Then the returned NFT should have "n" less uses.
-//   spok(t, usedNft, {
-//     $topic: 'use-nft',
-//     uses: {
-//       useMethod: UseMethod.Multiple,
-//       remaining: spokSameBignum(totalUses - timesToUse),
-//       total: spokSameBignum(totalUses),
-//     },
-//   } as unknown as Specifications<Nft>);
+  // Then the returned NFT should have "n" less uses.
+  spok(t, usedNft, {
+    $topic: 'use-nft',
+    uses: {
+      useMethod: UseMethod.Multiple,
+      remaining: spokSameBignum(totalUses - timesToUse),
+      total: spokSameBignum(totalUses),
+    },
+  } as unknown as Specifications<Nft>);
 
-//   // And the same goes if we try to fetch the NFT again.
-//   const foundUsedNft = await mx.nfts().findByMint(nft.mint);
-//   spok(t, foundUsedNft, {
-//     $topic: 'check-downloaded-nft',
-//     uses: {
-//       useMethod: UseMethod.Multiple,
-//       remaining: spokSameBignum(totalUses - timesToUse),
-//       total: spokSameBignum(totalUses),
-//     },
-//   } as unknown as Specifications<Nft>);
-// });
+  // And the same goes if we try to fetch the NFT again.
+  const foundUsedNft = await mx.nfts().findByMint(nft.mint);
+  spok(t, foundUsedNft, {
+    $topic: 'check-downloaded-nft',
+    uses: {
+      useMethod: UseMethod.Multiple,
+      remaining: spokSameBignum(totalUses - timesToUse),
+      total: spokSameBignum(totalUses),
+    },
+  } as unknown as Specifications<Nft>);
+});

--- a/test/plugins/nftModule/useNft.test.ts
+++ b/test/plugins/nftModule/useNft.test.ts
@@ -1,7 +1,8 @@
 import test, { Test } from 'tape';
 import spok, { Specifications } from 'spok';
-import { Nft, useMetaplexFile } from '@/index';
+import { MetaplexError, Nft, useMetaplexFile } from '@/index';
 import { UseMethod } from '@metaplex-foundation/mpl-token-metadata';
+import { Keypair } from '@solana/web3.js';
 import {
   metaplex,
   createNft,
@@ -110,3 +111,71 @@ test('it can use an nft multiple times', async (t: Test) => {
     },
   } as unknown as Specifications<Nft>);
 });
+
+test('it only allows the owner to update the uses', async (t: Test) => {
+  // Given we have a Metaplex instance.
+  const mx = await metaplex();
+
+  // And an existing SFT owned by owner.
+  const owner = Keypair.generate().publicKey;
+
+  const nft = await createNft(
+    mx,
+    {
+      name: 'JSON SFT name',
+      description: 'JSON SFT description',
+      image: useMetaplexFile('some image', 'some-image.jpg'),
+    },
+    {
+      name: 'On-chain SFT name',
+      owner,
+      isMutable: true,
+      uses: {
+        useMethod: UseMethod.Multiple,
+        remaining: 10,
+        total: 10,
+      },
+    }
+  );
+
+  // When the wrong owner uses the NFT
+  try {
+    await mx.nfts().use(nft);
+  } catch (error) {
+    // Then we should get a MetaplexError.
+    t.equal(error instanceof MetaplexError, true);
+  }
+});
+
+test('it can only be used up to the total uses', async (t: Test) => {
+  // Given we have a Metaplex instance.
+  const mx = await metaplex();
+
+  // And an existing SFT with no remaining uses.
+  const nft = await createNft(
+    mx,
+    {
+      name: 'JSON SFT name',
+      description: 'JSON SFT description',
+      image: useMetaplexFile('some image', 'some-image.jpg'),
+    },
+    {
+      name: 'On-chain SFT name',
+      isMutable: true,
+      uses: {
+        useMethod: UseMethod.Multiple,
+        remaining: 1,
+        total: 10,
+      },
+    }
+  );
+
+  // It throws an error when there are no remaining uses.
+  try {
+    await mx.nfts().use(nft, { numberOfUses: 2 });
+  } catch (error) {
+    t.match((error as MetaplexError).problem, /not enough uses/i);
+  }
+});
+
+test;

--- a/test/plugins/nftModule/useNft.test.ts
+++ b/test/plugins/nftModule/useNft.test.ts
@@ -1,0 +1,114 @@
+import test, { Test } from 'tape';
+import spok, { Specifications } from 'spok';
+import { Nft, useMetaplexFile } from '@/index';
+import { UseMethod } from '@metaplex-foundation/mpl-token-metadata';
+import {
+  metaplex,
+  createNft,
+  killStuckProcess,
+  spokSameBignum,
+} from '../../helpers';
+
+killStuckProcess();
+
+test('it can use an nft', async (t: Test) => {
+  // Given we have a Metaplex instance.
+  const mx = await metaplex();
+
+  // And an existing SFT.
+  const nft = await createNft(
+    mx,
+    {
+      name: 'JSON SFT name',
+      description: 'JSON SFT description',
+      image: useMetaplexFile('some image', 'some-image.jpg'),
+    },
+    {
+      name: 'On-chain SFT name',
+      isMutable: true,
+      uses: {
+        useMethod: 1,
+        remaining: 10,
+        total: 10,
+      },
+    }
+  );
+
+  // When we use the NFT once.
+  const { nft: usedNft } = await mx.nfts().use(nft);
+
+  // Then the returned SFT should have one less use.
+  spok(t, usedNft, {
+    $topic: 'use-nft',
+    uses: {
+      useMethod: UseMethod.Multiple,
+      remaining: spokSameBignum(9),
+      total: spokSameBignum(10),
+    },
+    primarySaleHappened: true,
+  } as unknown as Specifications<Nft>);
+
+  // And the same goes if we try to fetch the NFT again.
+  const foundUpdatedNft = await mx.nfts().findByMint(nft.mint);
+  spok(t, foundUpdatedNft, {
+    $topic: 'check-downloaded-nft',
+    uses: {
+      useMethod: UseMethod.Multiple,
+      remaining: spokSameBignum(9),
+      total: spokSameBignum(10),
+    },
+    primarySaleHappened: true,
+  } as unknown as Specifications<Nft>);
+});
+
+test('it can use an nft multiple times', async (t: Test) => {
+  const totalUses = 10;
+  const timesToUse = 3;
+  // Given we have a Metaplex instance.
+  const mx = await metaplex();
+
+  // And an existing SFT.
+  const nft = await createNft(
+    mx,
+    {
+      name: 'JSON SFT name',
+      description: 'JSON SFT description',
+      image: useMetaplexFile('some image', 'some-image.jpg'),
+    },
+    {
+      name: 'On-chain SFT name',
+      isMutable: true,
+      uses: {
+        useMethod: 1,
+        remaining: totalUses,
+        total: totalUses,
+      },
+    }
+  );
+
+  // When we use the NFT once.
+  const { nft: usedNft } = await mx.nfts().use(nft, timesToUse);
+
+  // Then the returned SFT should have one n less uses.
+  spok(t, usedNft, {
+    $topic: 'use-nft',
+    uses: {
+      useMethod: UseMethod.Multiple,
+      remaining: spokSameBignum(totalUses - timesToUse),
+      total: spokSameBignum(totalUses),
+    },
+    primarySaleHappened: true,
+  } as unknown as Specifications<Nft>);
+
+  // And the same goes if we try to fetch the NFT again.
+  const foundUsedNft = await mx.nfts().findByMint(nft.mint);
+  spok(t, foundUsedNft, {
+    $topic: 'check-downloaded-nft',
+    uses: {
+      useMethod: UseMethod.Multiple,
+      remaining: spokSameBignum(totalUses - timesToUse),
+      total: spokSameBignum(totalUses),
+    },
+    primarySaleHappened: true,
+  } as unknown as Specifications<Nft>);
+});

--- a/test/plugins/nftModule/useNft.test.ts
+++ b/test/plugins/nftModule/useNft.test.ts
@@ -27,7 +27,7 @@ test('it can use an nft', async (t: Test) => {
       name: 'On-chain SFT name',
       isMutable: true,
       uses: {
-        useMethod: 1,
+        useMethod: UseMethod.Multiple,
         remaining: 10,
         total: 10,
       },
@@ -45,7 +45,6 @@ test('it can use an nft', async (t: Test) => {
       remaining: spokSameBignum(9),
       total: spokSameBignum(10),
     },
-    primarySaleHappened: true,
   } as unknown as Specifications<Nft>);
 
   // And the same goes if we try to fetch the NFT again.

--- a/test/plugins/nftModule/useNft.test.ts
+++ b/test/plugins/nftModule/useNft.test.ts
@@ -56,58 +56,57 @@ test('it can use an nft', async (t: Test) => {
       remaining: spokSameBignum(9),
       total: spokSameBignum(10),
     },
-    primarySaleHappened: true,
   } as unknown as Specifications<Nft>);
 });
 
-test('it can use an nft multiple times', async (t: Test) => {
-  const totalUses = 10;
-  const timesToUse = 3;
-  // Given we have a Metaplex instance.
-  const mx = await metaplex();
+// test('it can use an nft multiple times', async (t: Test) => {
+//   const totalUses = 10;
+//   const timesToUse = 3;
+//   // Given we have a Metaplex instance.
+//   const mx = await metaplex();
 
-  // And an existing SFT.
-  const nft = await createNft(
-    mx,
-    {
-      name: 'JSON SFT name',
-      description: 'JSON SFT description',
-      image: useMetaplexFile('some image', 'some-image.jpg'),
-    },
-    {
-      name: 'On-chain SFT name',
-      isMutable: true,
-      uses: {
-        useMethod: 1,
-        remaining: totalUses,
-        total: totalUses,
-      },
-    }
-  );
+//   // And an existing SFT.
+//   const nft = await createNft(
+//     mx,
+//     {
+//       name: 'JSON SFT name',
+//       description: 'JSON SFT description',
+//       image: useMetaplexFile('some image', 'some-image.jpg'),
+//     },
+//     {
+//       name: 'On-chain SFT name',
+//       isMutable: true,
+//       uses: {
+//         useMethod: 1,
+//         remaining: totalUses,
+//         total: totalUses,
+//       },
+//     }
+//   );
 
-  // When we use the NFT once.
-  const { nft: usedNft } = await mx.nfts().use(nft, timesToUse);
+//   // When we use the NFT "n" times.
+//   const { nft: usedNft } = await mx
+//     .nfts()
+//     .use(nft, { numberOfUses: timesToUse });
 
-  // Then the returned SFT should have one n less uses.
-  spok(t, usedNft, {
-    $topic: 'use-nft',
-    uses: {
-      useMethod: UseMethod.Multiple,
-      remaining: spokSameBignum(totalUses - timesToUse),
-      total: spokSameBignum(totalUses),
-    },
-    primarySaleHappened: true,
-  } as unknown as Specifications<Nft>);
+//   // Then the returned NFT should have "n" less uses.
+//   spok(t, usedNft, {
+//     $topic: 'use-nft',
+//     uses: {
+//       useMethod: UseMethod.Multiple,
+//       remaining: spokSameBignum(totalUses - timesToUse),
+//       total: spokSameBignum(totalUses),
+//     },
+//   } as unknown as Specifications<Nft>);
 
-  // And the same goes if we try to fetch the NFT again.
-  const foundUsedNft = await mx.nfts().findByMint(nft.mint);
-  spok(t, foundUsedNft, {
-    $topic: 'check-downloaded-nft',
-    uses: {
-      useMethod: UseMethod.Multiple,
-      remaining: spokSameBignum(totalUses - timesToUse),
-      total: spokSameBignum(totalUses),
-    },
-    primarySaleHappened: true,
-  } as unknown as Specifications<Nft>);
-});
+//   // And the same goes if we try to fetch the NFT again.
+//   const foundUsedNft = await mx.nfts().findByMint(nft.mint);
+//   spok(t, foundUsedNft, {
+//     $topic: 'check-downloaded-nft',
+//     uses: {
+//       useMethod: UseMethod.Multiple,
+//       remaining: spokSameBignum(totalUses - timesToUse),
+//       total: spokSameBignum(totalUses),
+//     },
+//   } as unknown as Specifications<Nft>);
+// });


### PR DESCRIPTION
Hey @lorisleiva ! I created this draft PR to start getting some feedback on the uses implementation I'm working on.

This adds support for "using" an NFT based on the Utilize instruction mentioned in the [Metaplex docs](https://docs.metaplex.com/programs/token-metadata/instructions#reduce-the-number-of-uses), and closes issue #101  It currently only supports the `owner` of the NFT being allowed to decrement the uses, so there will need to be more support for handling a `useAuthority`.

Work that's left:
- [ ] Add documentation for `uses` to the README
- [ ] Add more unit tests for different edge cases
- [ ] Support a `useAuthority` through a `useAuthorityRecord`
- [ ] Support a `burner`
- [ ] Improve error handling for misused (no pun intended) NFTs