### PR TITLE
Add Auctioneer delegate & extend Bid to allow Auctioneer

### DIFF
--- a/packages/js/src/plugins/auctionHouseModule/AuctionHouse.ts
+++ b/packages/js/src/plugins/auctionHouseModule/AuctionHouse.ts
@@ -19,6 +19,7 @@ export type AuctionHouse = Readonly<{
   requiresSignOff: boolean;
   canChangeSalePrice: boolean;
   isNative: boolean;
+  hasAuctioneer: boolean;
 }>;
 
 export const isAuctionHouse = (value: any): value is AuctionHouse =>
@@ -54,5 +55,6 @@ export const toAuctionHouse = (
   sellerFeeBasisPoints: auctionHouseAccount.data.sellerFeeBasisPoints,
   requiresSignOff: auctionHouseAccount.data.requiresSignOff,
   canChangeSalePrice: auctionHouseAccount.data.canChangeSalePrice,
+  hasAuctioneer: auctionHouseAccount.data.hasAuctioneer,
   isNative: treasuryMint.isWrappedSol,
 });

--- a/packages/js/src/plugins/auctionHouseModule/createListing.ts
+++ b/packages/js/src/plugins/auctionHouseModule/createListing.ts
@@ -55,7 +55,7 @@ export type CreateListingInput = {
   auctioneerAuthority?: Signer; // Use Auctioneer ix when provided
   mintAccount: PublicKey; // Required for checking Metadata
   tokenAccount?: PublicKey; // Default: ATA
-  price?: SolAmount | SplTokenAmount; // Default: 0 SOLs or tokens.
+  price?: SolAmount | SplTokenAmount; // Default: 0 SOLs or tokens, ignored in Auctioneer.
   tokens?: SplTokenAmount; // Default: token(1)
   bookkeeper?: Signer; // Default: identity
   printReceipt?: boolean; // Default: true
@@ -214,7 +214,9 @@ export const createListingBuilder = (
       })
 
       // Print the Listing Receipt.
-      .when(params.printReceipt ?? true, (builder) =>
+      // Since createPrintListingReceiptInstruction can't deserialize createAuctioneerSellInstruction due to a bug
+      // Don't print Auctioneer Sell receipt for the time being.
+      .when(params.printReceipt ?? !params.auctioneerAuthority, (builder) =>
         builder.add({
           instruction: createPrintListingReceiptInstruction(
             {

--- a/packages/js/test/plugins/auctionHouseModule/createBid.test.ts
+++ b/packages/js/test/plugins/auctionHouseModule/createBid.test.ts
@@ -1,3 +1,4 @@
+import { Keypair } from '@solana/web3.js';
 import test, { Test } from 'tape';
 import spok, { Specifications } from 'spok';
 import { sol, token } from '@/types';
@@ -13,6 +14,7 @@ import {
 import { createAuctionHouse } from './helpers';
 import { findAssociatedTokenAccountPda } from '@/plugins';
 import { Bid } from '@/plugins/auctionHouseModule/Bid';
+import { AuthorityScope } from '@metaplex-foundation/mpl-auction-house';
 
 killStuckProcess();
 
@@ -206,5 +208,105 @@ test('[auctionHouseModule] create public receipt-less bid but cannot fetch it af
     t,
     promise,
     /The account of type \[BidReceipt\] was not found/
+  );
+});
+
+test('[auctionHouseModule] create private receipt-less Auctioneer bid but cannot fetch it afterwards by default', async (t: Test) => {
+  // Given we have an Auction House and an NFT.
+  const mx = await metaplex();
+  const seller = await createWallet(mx);
+  const nft = await createNft(mx, {}, { owner: seller.publicKey });
+
+  const auctioneerAuthority = Keypair.generate();
+
+  const { client } = await createAuctionHouse(mx, {
+    auctioneerAuthority,
+  });
+
+  // When we create a private bid on that NFT for 1 SOL.
+  const { bid, buyerTradeState } = await client
+    .bid({
+      mintAccount: nft.mintAddress,
+      seller: seller.publicKey,
+      price: sol(1),
+    })
+    .run();
+
+  // Then we created and returned the new Bid with appropriate defaults.
+  t.equal(bid.tradeStateAddress, buyerTradeState);
+  t.same(bid.price, sol(1));
+  t.same(bid.tokens, token(1));
+  t.false(bid.isPublic);
+
+  // But we cannot retrieve it later with the default operation handler.
+  const promise = client.findBidByAddress(buyerTradeState).run();
+  await assertThrows(
+    t,
+    promise,
+    /The account of type \[BidReceipt\] was not found/
+  );
+});
+
+test('[auctionHouseModule] create public receipt-less Auctioneer bid but cannot fetch it afterwards by default', async (t: Test) => {
+  // Given we have an Auction House and an NFT.
+  const mx = await metaplex();
+  const seller = await createWallet(mx);
+  const nft = await createNft(mx, {}, { owner: seller.publicKey });
+
+  const auctioneerAuthority = Keypair.generate();
+
+  const { client } = await createAuctionHouse(mx, {
+    auctioneerAuthority,
+  });
+
+  // When we create a public bid on that NFT for 1 SOL.
+  const { bid, buyerTradeState } = await client
+    .bid({
+      mintAccount: nft.mintAddress,
+      price: sol(1),
+    })
+    .run();
+
+  // Then we created and returned the new Bid with appropriate defaults.
+  t.equal(bid.tradeStateAddress, buyerTradeState);
+  t.same(bid.price, sol(1));
+  t.same(bid.tokens, token(1));
+  t.ok(bid.isPublic);
+
+  // But we cannot retrieve it later with the default operation handler.
+  const promise = client.findBidByAddress(buyerTradeState).run();
+  await assertThrows(
+    t,
+    promise,
+    /The account of type \[BidReceipt\] was not found/
+  );
+});
+
+test('[auctionHouseModule] create private receipt-less Auctioneer with invalid scope', async (t: Test) => {
+  // Given we have an Auction House and an NFT.
+  const mx = await metaplex();
+  const seller = await createWallet(mx);
+  const nft = await createNft(mx, {}, { owner: seller.publicKey });
+
+  const auctioneerAuthority = Keypair.generate();
+
+  const { client } = await createAuctionHouse(mx, {
+    auctioneerAuthority,
+    auctioneerScopes: [AuthorityScope.Sell],
+  });
+
+  // When we create a private bid on that NFT for 1 SOL.
+  const promise = client
+    .bid({
+      mintAccount: nft.mintAddress,
+      seller: seller.publicKey,
+      price: sol(1),
+    })
+    .run();
+
+  await assertThrows(
+    t,
+    promise,
+    /The Auctioneer does not have the correct scope for this action/
   );
 });

--- a/packages/js/test/plugins/auctionHouseModule/helpers.ts
+++ b/packages/js/test/plugins/auctionHouseModule/helpers.ts
@@ -18,6 +18,6 @@ export const createAuctionHouse = async (
 
   return {
     auctionHouse,
-    client: mx.auctions().for(auctionHouse),
+    client: mx.auctions().for(auctionHouse, input.auctioneerAuthority),
   };
 };


### PR DESCRIPTION
Implements delegation of Auctioneer at AH creation/update. Allows providing a scope of whitelisted actions.
Extends Create Bid to accept Auctioneer instruction.

Currently, it's not possible to print receipts for Auctioneer instructions due to an issue on the program side.