### PR TITLE
fix: create(input) links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Note that `MetaplexFile`s can be created in various different ways based on wher
 
 ### create
 
-The `create` method accepts [a variety of parameters](/src/plugins/nftModule/createNft.ts) that define the on-chain data of the NFT. The only parameters required are its `name`, its `sellerFeeBasisPoints` — i.e. royalties — and the `uri` pointing to its JSON metadata — remember that you can use `uploadMetadata` to get that URI. All other parameters are optional as the SDK will do its best to provide sensible default values.
+The `create` method accepts [a variety of parameters](/packages/js/src/plugins/nftModule/createNft.ts) that define the on-chain data of the NFT. The only parameters required are its `name`, its `sellerFeeBasisPoints` — i.e. royalties — and the `uri` pointing to its JSON metadata — remember that you can use `uploadMetadata` to get that URI. All other parameters are optional as the SDK will do its best to provide sensible default values.
 
 Here's how you can create a new NFT with minimum configuration.
 
@@ -254,7 +254,7 @@ Additionally, since no other optional parameters were provided, it will do its b
 - It will also default to setting the identity as the first and only creator with a 100% share.
 - It will default to making the NFT mutable — meaning the update authority will be able to update it later on.
 
-If some of these default parameters are not suitable for your use case, you may provide them explicitly when creating the NFT. [Here is the exhaustive list of parameters](/src/plugins/nftModule/createNft.ts) accepted by the `create` method.
+If some of these default parameters are not suitable for your use case, you may provide them explicitly when creating the NFT. [Here is the exhaustive list of parameters](/packages/js/src/plugins/nftModule/createNft.ts) accepted by the `create` method.
 
 ### update
 


### PR DESCRIPTION
Just fixed the createNfts() links in the README. Thank you for all the hardwork Metaplex team!