### PR TITLE
Add program address and version to Candy Machine model

### DIFF
--- a/packages/js/src/plugins/candyMachineModule/CandyMachine.ts
+++ b/packages/js/src/plugins/candyMachineModule/CandyMachine.ts
@@ -25,6 +25,7 @@ import {
   MaybeCandyMachineCollectionAccount,
 } from './accounts';
 import { Creator } from '@/types/Creator';
+import { CandyMachineProgram } from './program';
 
 // -----------------
 // Model
@@ -33,6 +34,8 @@ import { Creator } from '@/types/Creator';
 export type CandyMachine = Readonly<{
   model: 'candyMachine';
   address: PublicKey;
+  programAddress: PublicKey;
+  version: 1 | 2;
   authorityAddress: PublicKey;
   walletAddress: PublicKey; // SOL treasury OR token account for the tokenMintAddress.
   tokenMintAddress: Option<PublicKey>;
@@ -123,6 +126,8 @@ export const toCandyMachine = (
   return {
     model: 'candyMachine',
     address: account.publicKey,
+    programAddress: account.owner,
+    version: account.owner.equals(CandyMachineProgram.publicKey) ? 2 : 1,
     authorityAddress: account.data.authority,
     walletAddress: account.data.wallet,
     tokenMintAddress: account.data.tokenMint,

--- a/packages/js/test/plugins/candyMachineModule/createCandyMachine.test.ts
+++ b/packages/js/test/plugins/candyMachineModule/createCandyMachine.test.ts
@@ -21,8 +21,9 @@ import {
   CreateCandyMachineInput,
   toBigNumber,
   toDateTime,
+  CandyMachineProgram,
+  getCandyMachineUuidFromAddress,
 } from '@/index';
-import { getCandyMachineUuidFromAddress } from '@/plugins/candyMachineModule/helpers';
 import { create32BitsHash, create32BitsHashString } from './helpers';
 
 killStuckProcess();
@@ -57,6 +58,8 @@ test('[candyMachineModule] create with minimal input', async (t) => {
   await tc.assertSuccess(t, response.signature);
   spok(t, candyMachine, {
     $topic: 'Candy Machine',
+    programAddress: spokSamePubkey(CandyMachineProgram.publicKey),
+    version: 2,
     tokenMintAddress: null,
     collectionMintAddress: null,
     uuid: getCandyMachineUuidFromAddress(candyMachine.address),


### PR DESCRIPTION
### Problem

Currently, when creating a `CandyMachine` model from the candy machine account, we lose the information regarding "which program" creating this account. This means the consumer cannot know if this Candy Machine used the version 1 or version 2 program.

### Solution

This PR fixes this by adding two more properties to the `CandyMachine` model:
- `programAddress` is the public key of the program that owns the candy machine account.
- `version` can either be `1` or `2` and identifies which Candy Machine program version was used.