### PR TITLE
Add warning that metaplex does not exist on localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The entry point to the JavaScript SDK is a `Metaplex` instance that will give yo
 
 It accepts a `Connection` instance from `@solana/web3.js` that will be used to communicate with the cluster.
 
+> **Note**
+> The metaplex program does not exist on localhost. Trying to use it when connected to localhost will fail with `Attempt to load a program that does not exist`. 
+
 ```ts
 import { Metaplex } from "@metaplex-foundation/js";
 import { Connection, clusterApiUrl } from "@solana/web3.js";


### PR DESCRIPTION
Heya! New metaplex user, I'm taking a guess - because it doesn't say here - that metaplex doesn't work on localhost with `solana-test-validator`. Is that correct? 

This was me after following the guide, and being used to other programs (like SPL token) that work on localhost:  https://solana.stackexchange.com/questions/1879/metaplex-create-fails-on-localhost-with-attempt-to-load-a-program-that-does-n 

So adding a note to others to make it clear they need to use another network. I hope it's useful!