### PR TITLE
Add Find Bid by Receipt to Auction House

### DIFF
--- a/packages/js/src/plugins/auctionHouseModule/findBidByReceipt.ts
+++ b/packages/js/src/plugins/auctionHouseModule/findBidByReceipt.ts
@@ -1,0 +1,59 @@
+import type { Commitment, PublicKey } from '@solana/web3.js';
+import type { Metaplex } from '@/Metaplex';
+import { useOperation, Operation, OperationHandler } from '@/types';
+import { AuctionHouse } from './AuctionHouse';
+import { DisposableScope } from '@/utils';
+import { Bid, toLazyBid } from './Bid';
+import { toBidReceiptAccount } from './accounts';
+
+// -----------------
+// Operation
+// -----------------
+
+const Key = 'FindBidByReceiptOperation' as const;
+export const findBidByReceiptOperation =
+  useOperation<FindBidByReceiptOperation>(Key);
+export type FindBidByReceiptOperation = Operation<
+  typeof Key,
+  FindBidByReceiptInput,
+  Bid
+>;
+
+export type FindBidByReceiptInput = {
+  receiptAddress: PublicKey;
+  auctionHouse: AuctionHouse;
+  loadJsonMetadata?: boolean; // Default: true
+  commitment?: Commitment;
+};
+
+// -----------------
+// Handler
+// -----------------
+
+export const findBidByReceiptOperationHandler: OperationHandler<FindBidByReceiptOperation> =
+  {
+    handle: async (
+      operation: FindBidByReceiptOperation,
+      metaplex: Metaplex,
+      scope: DisposableScope
+    ) => {
+      const {
+        receiptAddress,
+        auctionHouse,
+        commitment,
+        loadJsonMetadata = true,
+      } = operation.input;
+
+      const account = toBidReceiptAccount(
+        await metaplex.rpc().getAccount(receiptAddress, commitment)
+      );
+      scope.throwIfCanceled();
+
+      const lazyBid = toLazyBid(account, auctionHouse);
+      return metaplex
+        .auctions()
+        .for(auctionHouse)
+        .loadBid(lazyBid, { loadJsonMetadata, commitment })
+        .run(scope);
+    },
+  };

--- a/packages/js/src/plugins/auctionHouseModule/findBidByTradeState.ts
+++ b/packages/js/src/plugins/auctionHouseModule/findBidByTradeState.ts
@@ -11,17 +11,17 @@ import { toBidReceiptAccount } from './accounts';
 // Operation
 // -----------------
 
-const Key = 'FindBidByAddressOperation' as const;
-export const findBidByAddressOperation =
-  useOperation<FindBidByAddressOperation>(Key);
-export type FindBidByAddressOperation = Operation<
+const Key = 'FindBidByTradeStateOperation' as const;
+export const findBidByTradeStateOperation =
+  useOperation<FindBidByTradeStateOperation>(Key);
+export type FindBidByTradeStateOperation = Operation<
   typeof Key,
-  FindBidByAddressInput,
+  FindBidByTradeStateInput,
   Bid
 >;
 
-export type FindBidByAddressInput = {
-  address: PublicKey;
+export type FindBidByTradeStateInput = {
+  tradeStateAddress: PublicKey;
   auctionHouse: AuctionHouse;
   loadJsonMetadata?: boolean; // Default: true
   commitment?: Commitment;
@@ -31,21 +31,21 @@ export type FindBidByAddressInput = {
 // Handler
 // -----------------
 
-export const findBidByAddressOperationHandler: OperationHandler<FindBidByAddressOperation> =
+export const findBidByTradeStateOperationHandler: OperationHandler<FindBidByTradeStateOperation> =
   {
     handle: async (
-      operation: FindBidByAddressOperation,
+      operation: FindBidByTradeStateOperation,
       metaplex: Metaplex,
       scope: DisposableScope
     ) => {
       const {
-        address,
+        tradeStateAddress,
         auctionHouse,
         commitment,
         loadJsonMetadata = true,
       } = operation.input;
 
-      const receiptAddress = findBidReceiptPda(address);
+      const receiptAddress = findBidReceiptPda(tradeStateAddress);
       const account = toBidReceiptAccount(
         await metaplex.rpc().getAccount(receiptAddress, commitment)
       );

--- a/packages/js/src/plugins/auctionHouseModule/index.ts
+++ b/packages/js/src/plugins/auctionHouseModule/index.ts
@@ -7,7 +7,7 @@ export * from './cancelListing';
 export * from './createAuctionHouse';
 export * from './errors';
 export * from './findAuctionHouseByAddress';
-export * from './findBidByAddress';
+export * from './findBidByTradeState';
 export * from './findListingByAddress';
 export * from './findPurchaseByAddress';
 export * from './Listing';

--- a/packages/js/src/plugins/auctionHouseModule/plugin.ts
+++ b/packages/js/src/plugins/auctionHouseModule/plugin.ts
@@ -26,9 +26,13 @@ import {
   findAuctionHouseByAddressOperationHandler,
 } from './findAuctionHouseByAddress';
 import {
-  findBidByAddressOperation,
-  findBidByAddressOperationHandler,
-} from './findBidByAddress';
+  findBidByReceiptOperation,
+  findBidByReceiptOperationHandler,
+} from './findBidByReceipt';
+import {
+  findBidByTradeStateOperation,
+  findBidByTradeStateOperationHandler,
+} from './findBidByTradeState';
 import {
   findListingByAddressOperation,
   findListingByAddressOperationHandler,
@@ -75,7 +79,11 @@ export const auctionHouseModule = (): MetaplexPlugin => ({
       findAuctionHouseByAddressOperation,
       findAuctionHouseByAddressOperationHandler
     );
-    op.register(findBidByAddressOperation, findBidByAddressOperationHandler);
+    op.register(findBidByReceiptOperation, findBidByReceiptOperationHandler);
+    op.register(
+      findBidByTradeStateOperation,
+      findBidByTradeStateOperationHandler
+    );
     op.register(
       findListingByAddressOperation,
       findListingByAddressOperationHandler

--- a/packages/js/test/plugins/auctionHouseModule/cancelBid.test.ts
+++ b/packages/js/test/plugins/auctionHouseModule/cancelBid.test.ts
@@ -35,7 +35,7 @@ test('[auctionHouseModule] cancel a Private Bid on an Auction House', async (t: 
 
   // Then bid receipt has canceled at date.
   const canceledBid = await client
-    .findBidByAddress(bid.tradeStateAddress)
+    .findBidByTradeState(bid.tradeStateAddress)
     .run();
   t.ok(canceledBid.canceledAt);
 
@@ -146,7 +146,7 @@ test('[auctionHouseModule] it throws an error if executing a sale with a cancele
 
   // When we execute a sale with given listing and canceled bid.
   const canceledBid = await client
-    .findBidByAddress(bid.tradeStateAddress)
+    .findBidByTradeState(bid.tradeStateAddress)
     .run();
   const promise = client.executeSale({ listing, bid: canceledBid }).run();
 

--- a/packages/js/test/plugins/auctionHouseModule/createBid.test.ts
+++ b/packages/js/test/plugins/auctionHouseModule/createBid.test.ts
@@ -12,7 +12,7 @@ import {
   createWallet,
 } from '../../helpers';
 import { createAuctionHouse } from './helpers';
-import { Bid, findAssociatedTokenAccountPda } from '@/index';
+import { Bid, findAssociatedTokenAccountPda, Pda } from '@/index';
 import { AuthorityScope } from '@metaplex-foundation/mpl-auction-house';
 
 killStuckProcess();
@@ -54,8 +54,10 @@ test('[auctionHouseModule] create a new public bid on an Auction House', async (
     ...expectedBid,
   } as unknown as Specifications<Bid>);
 
-  // And we get the same result when we fetch the Auction House by address.
-  const retrieveBid = await client.findBidByAddress(buyerTradeState).run();
+  // And we get the same result when we fetch the Bid by address.
+  const retrieveBid = await client
+    .findBidByReceipt(bid.receiptAddress as Pda)
+    .run();
   spok(t, retrieveBid, {
     $topic: 'Retrieved Bid',
     ...expectedBid,
@@ -173,7 +175,7 @@ test('[auctionHouseModule] create private receipt-less bid but cannot fetch it a
   t.false(bid.receiptAddress);
 
   // But we cannot retrieve it later with the default operation handler.
-  const promise = client.findBidByAddress(buyerTradeState).run();
+  const promise = client.findBidByTradeState(bid.tradeStateAddress).run();
   await assertThrows(
     t,
     promise,
@@ -205,7 +207,7 @@ test('[auctionHouseModule] create public receipt-less bid but cannot fetch it af
   t.ok(bid.isPublic);
 
   // But we cannot retrieve it later with the default operation handler.
-  const promise = client.findBidByAddress(buyerTradeState).run();
+  const promise = client.findBidByTradeState(bid.tradeStateAddress).run();
   await assertThrows(
     t,
     promise,


### PR DESCRIPTION
* Adds Find Bid by Receipt.
* Renames findBidByAddress to findBidByTradeState to be consistent and less unclear.