### PR TITLE
wip: move cancelListion in AuctionsClient

### DIFF
--- a/packages/js/src/plugins/auctionHouseModule/AuctionHouseClient.ts
+++ b/packages/js/src/plugins/auctionHouseModule/AuctionHouseClient.ts
@@ -41,11 +41,11 @@ import {
   cancelBidOperation,
   CancelBidOutput,
 } from './cancelBid';
-import {
-  CancelListingInput,
-  cancelListingOperation,
-  CancelListingOutput,
-} from './cancelListing';
+// import {
+//   CancelListingInput,
+//   cancelListingOperation,
+//   CancelListingOutput,
+// } from './cancelListing';
 
 type WithoutAH<T> = Omit<T, 'auctionHouse' | 'auctioneerAuthority'>;
 
@@ -54,7 +54,7 @@ export class AuctionHouseClient {
     protected readonly metaplex: Metaplex,
     protected readonly auctionHouse: AuctionHouse,
     protected readonly auctioneerAuthority?: Signer
-  ) {}
+  ) { }
 
   cancelBid(input: WithoutAH<CancelBidInput>): Task<CancelBidOutput> {
     return this.metaplex
@@ -62,13 +62,13 @@ export class AuctionHouseClient {
       .getTask(cancelBidOperation(this.addAH(input)));
   }
 
-  cancelListing(
-    input: WithoutAH<CancelListingInput>
-  ): Task<CancelListingOutput> {
-    return this.metaplex
-      .operations()
-      .getTask(cancelListingOperation(this.addAH(input)));
-  }
+  // cancelListing(
+  //   input: WithoutAH<CancelListingInput>
+  // ): Task<CancelListingOutput> {
+  //   return this.metaplex
+  //     .operations()
+  //     .getTask(cancelListingOperation(this.addAH(input)));
+  // }
 
   executeSale(
     input: WithoutAH<ExecuteSaleInput>

--- a/packages/js/src/plugins/auctionHouseModule/AuctionHouseClient.ts
+++ b/packages/js/src/plugins/auctionHouseModule/AuctionHouseClient.ts
@@ -41,11 +41,6 @@ import {
   cancelBidOperation,
   CancelBidOutput,
 } from './cancelBid';
-// import {
-//   CancelListingInput,
-//   cancelListingOperation,
-//   CancelListingOutput,
-// } from './cancelListing';
 
 type WithoutAH<T> = Omit<T, 'auctionHouse' | 'auctioneerAuthority'>;
 
@@ -61,14 +56,6 @@ export class AuctionHouseClient {
       .operations()
       .getTask(cancelBidOperation(this.addAH(input)));
   }
-
-  // cancelListing(
-  //   input: WithoutAH<CancelListingInput>
-  // ): Task<CancelListingOutput> {
-  //   return this.metaplex
-  //     .operations()
-  //     .getTask(cancelListingOperation(this.addAH(input)));
-  // }
 
   executeSale(
     input: WithoutAH<ExecuteSaleInput>

--- a/packages/js/src/plugins/auctionHouseModule/AuctionsClient.ts
+++ b/packages/js/src/plugins/auctionHouseModule/AuctionsClient.ts
@@ -20,15 +20,10 @@ import {
 } from './updateAuctionHouse';
 import { AuctionHouseClient } from './AuctionHouseClient';
 import { Signer } from '@/types';
-import {
-  CancelListingInput,
-  cancelListingOperation,
-  CancelListingOutput,
-} from './cancelListing';
+import { CancelListingInput, cancelListingOperation, CancelListingOutput } from './cancelListing';
 
 export class AuctionsClient {
-  constructor(
-    protected readonly metaplex: Metaplex,
+  constructor(protected readonly metaplex: Metaplex,
     protected readonly auctionHouse: AuctionHouse,
     protected readonly auctioneerAuthority?: Signer) { }
 
@@ -45,7 +40,6 @@ export class AuctionsClient {
   }
 
   cancelListing(
-    // this: AuctionsClient,
     input: CancelListingInput
   ): Task<CancelListingOutput> {
     return this.metaplex
@@ -55,7 +49,7 @@ export class AuctionsClient {
 
   createAuctionHouse(
     input: CreateAuctionHouseInput
-  ): Task<CreateAuctionHouseOutput> {
+  ): Task<CreateAuctionHouseOutput & { auctionHouse: AuctionHouse }> {
     return new Task(async (scope) => {
       const output = await this.metaplex
         .operations()

--- a/packages/js/src/plugins/auctionHouseModule/AuctionsClient.ts
+++ b/packages/js/src/plugins/auctionHouseModule/AuctionsClient.ts
@@ -20,9 +20,17 @@ import {
 } from './updateAuctionHouse';
 import { AuctionHouseClient } from './AuctionHouseClient';
 import { Signer } from '@/types';
+import {
+  CancelListingInput,
+  cancelListingOperation,
+  CancelListingOutput,
+} from './cancelListing';
 
 export class AuctionsClient {
-  constructor(protected readonly metaplex: Metaplex) {}
+  constructor(
+    protected readonly metaplex: Metaplex,
+    protected readonly auctionHouse: AuctionHouse,
+    protected readonly auctioneerAuthority?: Signer) { }
 
   builders() {
     return new AuctionsBuildersClient(this.metaplex);
@@ -36,9 +44,18 @@ export class AuctionsClient {
     );
   }
 
+  cancelListing(
+    // this: AuctionsClient,
+    input: CancelListingInput
+  ): Task<CancelListingOutput> {
+    return this.metaplex
+      .operations()
+      .getTask(cancelListingOperation(input));
+  }
+
   createAuctionHouse(
     input: CreateAuctionHouseInput
-  ): Task<CreateAuctionHouseOutput & { auctionHouse: AuctionHouse }> {
+  ): Task<CreateAuctionHouseOutput> {
     return new Task(async (scope) => {
       const output = await this.metaplex
         .operations()

--- a/packages/js/test/plugins/auctionHouseModule/cancelListing.test.ts
+++ b/packages/js/test/plugins/auctionHouseModule/cancelListing.test.ts
@@ -17,7 +17,7 @@ test('[auctionHouseModule] cancel a Listing on an Auction House', async (t: Test
   const mx = await metaplex();
 
   const nft = await createNft(mx);
-  const { client } = await createAuctionHouse(mx);
+  const { client, auctionHouse } = await createAuctionHouse(mx);
 
   // And we listed that NFT for 1 SOL.
   const { listing } = await client
@@ -31,7 +31,7 @@ test('[auctionHouseModule] cancel a Listing on an Auction House', async (t: Test
   t.ok(listing.asset.token.delegateAddress);
 
   // When we cancel the given listing.
-  await client.cancelListing({ listing }).run();
+  await client.cancelListing({ auctionHouse, listing }).run();
 
   // Then the delegate's authority is revoked and receipt has canceledAt date.
   const canceledListing = await client
@@ -51,7 +51,7 @@ test('[auctionHouseModule] cancel a Listing on an Auctioneer Auction House', asy
 
   const nft = await createNft(mx);
   const auctioneerAuthority = Keypair.generate();
-  const { client } = await createAuctionHouse(mx, auctioneerAuthority);
+  const { client, auctionHouse } = await createAuctionHouse(mx, auctioneerAuthority);
 
   // And we list that NFT.
   const { listing } = await client
@@ -61,7 +61,7 @@ test('[auctionHouseModule] cancel a Listing on an Auctioneer Auction House', asy
     .run();
 
   // When we cancel the given listing.
-  await client.cancelListing({ listing }).run();
+  await client.cancelListing({ auctionHouse, listing }).run();
 
   // Then the trade state account no longer exists.
   const listingAccount = await mx.rpc().getAccount(listing.tradeStateAddress);
@@ -74,7 +74,7 @@ test('[auctionHouseModule] it throws an error if executing a sale with a cancele
   const buyer = await createWallet(mx);
 
   const nft = await createNft(mx);
-  const { client } = await createAuctionHouse(mx);
+  const { client, auctionHouse } = await createAuctionHouse(mx);
 
   // And we listed that NFT for 1 SOL.
   const { listing } = await client
@@ -94,7 +94,7 @@ test('[auctionHouseModule] it throws an error if executing a sale with a cancele
     .run();
 
   // And we cancel the given listing.
-  await client.cancelListing({ listing }).run();
+  await client.cancelListing({ auctionHouse, listing }).run();
 
   // When we execute a sale with given canceled listing and bid.
   const canceledListing = await client
@@ -131,8 +131,7 @@ test('[auctionHouseModule] it throws an error if Auctioneer Authority is not pro
   // When we cancel the listing but without providing Auctioneer Authority.
   const promise = mx
     .auctions()
-    .for(auctionHouse)
-    .cancelListing({ listing })
+    .cancelListing({ auctionHouse, listing })
     .run();
 
   // Then we expect an error.


### PR DESCRIPTION
- Move the appropriate methods from AuctionHouseClient to AuctionsClient.
- Remove the .for() method. 