### PR TITLE
Add Find Purchase by Receipt to Auction House

### DIFF
--- a/packages/js/src/plugins/auctionHouseModule/findListingByTradeState.ts
+++ b/packages/js/src/plugins/auctionHouseModule/findListingByTradeState.ts
@@ -1,9 +1,8 @@
 import type { Commitment, PublicKey } from '@solana/web3.js';
 import type { Metaplex } from '@/Metaplex';
 import { useOperation, Operation, OperationHandler } from '@/types';
-import { toListingReceiptAccount } from './accounts';
 import { AuctionHouse } from './AuctionHouse';
-import { Listing, toLazyListing } from './Listing';
+import { Listing } from './Listing';
 import { DisposableScope } from '@/utils';
 import { findListingReceiptPda } from './pdas';
 
@@ -60,16 +59,11 @@ export const findListingByTradeStateOperationHandler: OperationHandler<FindListi
       } = operation.input;
 
       const receiptAddress = findListingReceiptPda(tradeStateAddress);
-      const account = toListingReceiptAccount(
-        await metaplex.rpc().getAccount(receiptAddress, commitment)
-      );
-      scope.throwIfCanceled();
 
-      const lazyListing = toLazyListing(account, auctionHouse);
       return metaplex
         .auctions()
         .for(auctionHouse)
-        .loadListing(lazyListing, { loadJsonMetadata, commitment })
+        .findListingByReceipt(receiptAddress, { loadJsonMetadata, commitment })
         .run(scope);
     },
   };

--- a/packages/js/src/plugins/auctionHouseModule/findPurchaseByReceipt.ts
+++ b/packages/js/src/plugins/auctionHouseModule/findPurchaseByReceipt.ts
@@ -5,28 +5,27 @@ import { toPurchaseReceiptAccount } from './accounts';
 import { AuctionHouse } from './AuctionHouse';
 import { DisposableScope } from '@/utils';
 import { Purchase, toLazyPurchase } from './Purchase';
-import { findPurchaseReceiptPda } from './pdas';
 
 // -----------------
 // Operation
 // -----------------
 
-const Key = 'FindPurchaseByAddressOperation' as const;
+const Key = 'FindPurchaseByReceiptOperation' as const;
 
 /**
  * @group Operations
  * @category Constructors
  */
-export const findPurchaseByAddressOperation =
-  useOperation<FindPurchaseByAddressOperation>(Key);
+export const findPurchaseByReceiptOperation =
+  useOperation<FindPurchaseByReceiptOperation>(Key);
 
 /**
  * @group Operations
  * @category Types
  */
-export type FindPurchaseByAddressOperation = Operation<
+export type FindPurchaseByReceiptOperation = Operation<
   typeof Key,
-  FindPurchaseByAddressInput,
+  FindPurchaseByReceiptInput,
   Purchase
 >;
 
@@ -34,9 +33,8 @@ export type FindPurchaseByAddressOperation = Operation<
  * @group Operations
  * @category Inputs
  */
-export type FindPurchaseByAddressInput = {
-  sellerTradeState: PublicKey;
-  buyerTradeState: PublicKey;
+export type FindPurchaseByReceiptInput = {
+  receiptAddress: PublicKey;
   auctionHouse: AuctionHouse;
   loadJsonMetadata?: boolean; // Default: true
   commitment?: Commitment;
@@ -46,25 +44,20 @@ export type FindPurchaseByAddressInput = {
  * @group Operations
  * @category Handlers
  */
-export const findPurchaseByAddressOperationHandler: OperationHandler<FindPurchaseByAddressOperation> =
+export const findPurchaseByReceiptOperationHandler: OperationHandler<FindPurchaseByReceiptOperation> =
   {
     handle: async (
-      operation: FindPurchaseByAddressOperation,
+      operation: FindPurchaseByReceiptOperation,
       metaplex: Metaplex,
       scope: DisposableScope
     ) => {
       const {
-        sellerTradeState,
-        buyerTradeState,
+        receiptAddress,
         auctionHouse,
         commitment,
         loadJsonMetadata = true,
       } = operation.input;
 
-      const receiptAddress = findPurchaseReceiptPda(
-        sellerTradeState,
-        buyerTradeState
-      );
       const account = toPurchaseReceiptAccount(
         await metaplex.rpc().getAccount(receiptAddress, commitment)
       );

--- a/packages/js/src/plugins/auctionHouseModule/findPurchaseByTradeState.ts
+++ b/packages/js/src/plugins/auctionHouseModule/findPurchaseByTradeState.ts
@@ -3,38 +3,39 @@ import type { Metaplex } from '@/Metaplex';
 import { useOperation, Operation, OperationHandler } from '@/types';
 import { AuctionHouse } from './AuctionHouse';
 import { DisposableScope } from '@/utils';
-import { findBidReceiptPda } from './pdas';
-import { Bid } from './Bid';
+import { Purchase } from './Purchase';
+import { findPurchaseReceiptPda } from './pdas';
 
 // -----------------
 // Operation
 // -----------------
 
-const Key = 'FindBidByTradeStateOperation' as const;
+const Key = 'FindPurchaseByTradeStateOperation' as const;
 
 /**
  * @group Operations
  * @category Constructors
  */
-export const findBidByTradeStateOperation =
-  useOperation<FindBidByTradeStateOperation>(Key);
+export const findPurchaseByTradeStateOperation =
+  useOperation<FindPurchaseByTradeStateOperation>(Key);
 
 /**
  * @group Operations
  * @category Types
  */
-export type FindBidByTradeStateOperation = Operation<
+export type FindPurchaseByTradeStateOperation = Operation<
   typeof Key,
-  FindBidByTradeStateInput,
-  Bid
+  FindPurchaseByTradeStateInput,
+  Purchase
 >;
 
 /**
  * @group Operations
  * @category Inputs
  */
-export type FindBidByTradeStateInput = {
-  tradeStateAddress: PublicKey;
+export type FindPurchaseByTradeStateInput = {
+  sellerTradeState: PublicKey;
+  buyerTradeState: PublicKey;
   auctionHouse: AuctionHouse;
   loadJsonMetadata?: boolean; // Default: true
   commitment?: Commitment;
@@ -44,26 +45,30 @@ export type FindBidByTradeStateInput = {
  * @group Operations
  * @category Handlers
  */
-export const findBidByTradeStateOperationHandler: OperationHandler<FindBidByTradeStateOperation> =
+export const findPurchaseByTradeStateOperationHandler: OperationHandler<FindPurchaseByTradeStateOperation> =
   {
     handle: async (
-      operation: FindBidByTradeStateOperation,
+      operation: FindPurchaseByTradeStateOperation,
       metaplex: Metaplex,
       scope: DisposableScope
     ) => {
       const {
-        tradeStateAddress,
+        sellerTradeState,
+        buyerTradeState,
         auctionHouse,
         commitment,
         loadJsonMetadata = true,
       } = operation.input;
 
-      const receiptAddress = findBidReceiptPda(tradeStateAddress);
+      const receiptAddress = findPurchaseReceiptPda(
+        sellerTradeState,
+        buyerTradeState
+      );
 
       return metaplex
         .auctions()
         .for(auctionHouse)
-        .findBidByReceipt(receiptAddress, { loadJsonMetadata, commitment })
+        .findPurchaseByReceipt(receiptAddress, { loadJsonMetadata, commitment })
         .run(scope);
     },
   };

--- a/packages/js/src/plugins/auctionHouseModule/index.ts
+++ b/packages/js/src/plugins/auctionHouseModule/index.ts
@@ -11,7 +11,7 @@ export * from './findBidByReceipt';
 export * from './findBidByTradeState';
 export * from './findListingByReceipt';
 export * from './findListingByTradeState';
-export * from './findPurchaseByAddress';
+export * from './findPurchaseByTradeState';
 export * from './Listing';
 export * from './loadBid';
 export * from './loadPurchase';

--- a/packages/js/src/plugins/auctionHouseModule/plugin.ts
+++ b/packages/js/src/plugins/auctionHouseModule/plugin.ts
@@ -42,9 +42,13 @@ import {
   findListingByTradeStateOperationHandler,
 } from './findListingByTradeState';
 import {
-  findPurchaseByAddressOperation,
-  findPurchaseByAddressOperationHandler,
-} from './findPurchaseByAddress';
+  findPurchaseByReceiptOperation,
+  findPurchaseByReceiptOperationHandler,
+} from './findPurchaseByReceipt';
+import {
+  findPurchaseByTradeStateOperation,
+  findPurchaseByTradeStateOperationHandler,
+} from './findPurchaseByTradeState';
 import {
   updateAuctionHouseOperation,
   updateAuctionHouseOperationHandler,
@@ -98,8 +102,12 @@ export const auctionHouseModule = (): MetaplexPlugin => ({
       findListingByTradeStateOperationHandler
     );
     op.register(
-      findPurchaseByAddressOperation,
-      findPurchaseByAddressOperationHandler
+      findPurchaseByReceiptOperation,
+      findPurchaseByReceiptOperationHandler
+    );
+    op.register(
+      findPurchaseByTradeStateOperation,
+      findPurchaseByTradeStateOperationHandler
     );
     op.register(loadBidOperation, loadBidOperationHandler);
     op.register(loadListingOperation, loadListingOperationHandler);

--- a/packages/js/test/plugins/auctionHouseModule/executeSale.test.ts
+++ b/packages/js/test/plugins/auctionHouseModule/executeSale.test.ts
@@ -14,6 +14,7 @@ import { createAuctionHouse } from './helpers';
 import {
   AccountNotFoundError,
   findAssociatedTokenAccountPda,
+  Pda,
   Purchase,
 } from '@/index';
 import { Keypair } from '@solana/web3.js';
@@ -74,7 +75,7 @@ test('[auctionHouseModule] execute sale on an Auction House', async (t: Test) =>
 
   // And we get the same result when we fetch the Purchase by address.
   const retrievePurchase = await client
-    .findPurchaseByAddress(listing.tradeStateAddress, bid.tradeStateAddress)
+    .findPurchaseByReceipt(purchase.receiptAddress as Pda)
     .run();
   spok(t, retrievePurchase, {
     $topic: 'Retrieved Purchase',
@@ -156,7 +157,10 @@ test('[auctionHouseModule] it executes receipt-less sale on an Auction House whe
   // But we cannot retrieve it later with the default operation handler.
   try {
     await client
-      .findPurchaseByAddress(listing.tradeStateAddress, bid.tradeStateAddress)
+      .findPurchaseByTradeState(
+        listing.tradeStateAddress,
+        bid.tradeStateAddress
+      )
       .run();
     t.fail('expected to throw AccountNotFoundError');
   } catch (error: any) {


### PR DESCRIPTION
- Adds Find Purchase by Receipt.
- Renames **findPurchaseByAddress** to **findPurchaseByTradeState** to be consistent and less unclear.
- Refactors other **findByTradeState** methods to reuse functionality.