### PR TITLE
Format Amount: fix decimals with leading zeroes

### DIFF
--- a/packages/js/src/types/Amount.ts
+++ b/packages/js/src/types/Amount.ts
@@ -244,7 +244,9 @@ export const formatAmount = (value: Amount): string => {
   };
 
   const { div, mod } = basisPoints.divmod(power);
-  const units = `${div.toString()}.${mod.abs().toString()}`;
+  const units = `${div.toString()}.${mod
+    .abs()
+    .toString(10, value.currency.decimals)}`;
 
   return `${value.currency.symbol} ${units}`;
 };

--- a/packages/js/test/types/Amount.test.ts
+++ b/packages/js/test/types/Amount.test.ts
@@ -39,10 +39,15 @@ test('[Amount] it can be formatted', (t: Test) => {
   const usdAmount = amount(1536, { symbol: 'USD', decimals: 2 });
   const gbpAmount = amount(4210, { symbol: 'GBP', decimals: 2 });
   const solAmount = amount(2_500_000_000, { symbol: 'SOL', decimals: 9 });
+  const solAmountLeadingZeroDecimal = amount(2_005_000_000, {
+    symbol: 'SOL',
+    decimals: 9,
+  });
 
   t.equal(formatAmount(usdAmount), 'USD 15.36');
   t.equal(formatAmount(gbpAmount), 'GBP 42.10');
   t.equal(formatAmount(solAmount), 'SOL 2.500000000');
+  t.equal(formatAmount(solAmountLeadingZeroDecimal), 'SOL 2.005000000');
   t.end();
 });
 


### PR DESCRIPTION
There is a bug that causes formatting of amounts with decimals to lose any leading zeroes.

Ex. 2005000000 lamports becomes "SOL 2.500000000" rather than "SOL 2.005000000"

This is because `mod` is always printed as an integer without leading zeroes. Incorporating decimal length in the toString() call fixes this. Added a test along with the fix to catch this going forward.