### PR TITLE
Candy Machine: accurate Amount if a `tokenMintAddress` is specified, fixes [#234]

### DIFF
--- a/packages/js/src/plugins/candyMachineModule/models/CandyMachine.ts
+++ b/packages/js/src/plugins/candyMachineModule/models/CandyMachine.ts
@@ -5,10 +5,12 @@ import {
   WhitelistMintMode,
 } from '@metaplex-foundation/mpl-candy-machine';
 import {
+  amount,
   Amount,
   BigNumber,
   DateTime,
   lamports,
+  SOL,
   toBigNumber,
   toDateTime,
   toOptionDateTime,
@@ -26,6 +28,7 @@ import {
 } from '../accounts';
 import { Creator } from '@/types';
 import { CandyMachineProgram } from '../program';
+import { Mint } from '@/plugins/tokenModule';
 
 // -----------------
 // Model
@@ -387,8 +390,15 @@ export function assertCandyMachine(value: any): asserts value is CandyMachine {
 export const toCandyMachine = (
   account: CandyMachineAccount,
   unparsedAccount: UnparsedAccount,
-  collectionAccount: MaybeCandyMachineCollectionAccount | null
+  collectionAccount: MaybeCandyMachineCollectionAccount | null,
+  mint: Mint | null
 ): CandyMachine => {
+  assert(
+    mint === null ||
+      (account.data.tokenMint !== null &&
+        mint.address.equals(account.data.tokenMint))
+  );
+
   const itemsAvailable = toBigNumber(account.data.data.itemsAvailable);
   const itemsMinted = toBigNumber(account.data.itemsRedeemed);
 
@@ -416,9 +426,7 @@ export const toCandyMachine = (
         ? collectionAccount.data.mint
         : null,
     uuid: account.data.data.uuid,
-
-    // TODO(loris): Provide a more accurate Amount if `tokenMintAddress` is not `null`.
-    price: lamports(account.data.data.price),
+    price: amount(account.data.data.price, mint ? mint.currency : SOL),
     symbol: removeEmptyChars(account.data.data.symbol),
     sellerFeeBasisPoints: account.data.data.sellerFeeBasisPoints,
     isMutable: account.data.data.isMutable,

--- a/packages/js/src/plugins/candyMachineModule/operations/findCandyMachineByAddress.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/findCandyMachineByAddress.ts
@@ -75,6 +75,13 @@ export const findCandyMachineByAddressOperationHandler: OperationHandler<FindCan
       const account = toCandyMachineAccount(unparsedAccount);
       const collectionAccount = parseCandyMachineCollectionAccount(accounts[1]);
 
-      return toCandyMachine(account, unparsedAccount, collectionAccount);
+      const mint = account.data.tokenMint
+        ? await metaplex
+            .tokens()
+            .findMintByAddress({ address: account.data.tokenMint })
+            .run()
+        : null;
+
+      return toCandyMachine(account, unparsedAccount, collectionAccount, mint);
     },
   };

--- a/packages/js/src/plugins/candyMachineModule/operations/findCandyMachinesByPublicKeyField.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/findCandyMachinesByPublicKeyField.ts
@@ -1,9 +1,11 @@
 import { UnreachableCaseError } from '@/errors';
 import { Metaplex } from '@/Metaplex';
+import { Mint, toMint, toMintAccount } from '@/plugins/tokenModule';
 import { Operation, OperationHandler, useOperation } from '@/types';
 import { DisposableScope, zipMap } from '@/utils';
 import { Commitment, PublicKey } from '@solana/web3.js';
 import {
+  CandyMachineAccount,
   parseCandyMachineAccount,
   parseCandyMachineCollectionAccount,
 } from '../accounts';
@@ -107,21 +109,58 @@ export const findCandyMachinesByPublicKeyFieldOperationHandler: OperationHandler
       const collectionPdas = unparsedAccounts.map((unparsedAccount) =>
         findCandyMachineCollectionPda(unparsedAccount.publicKey)
       );
-      const unparsedCollectionAccounts = await metaplex
+
+      // Find mint details for all unique SPL tokens used
+      // in candy machines that have non-null `tokenMint`
+
+      const parsedAccounts: Record<string, CandyMachineAccount> =
+        Object.fromEntries(
+          unparsedAccounts.map((unparsedAccount) => [
+            unparsedAccount.publicKey.toString(),
+            parseCandyMachineAccount(unparsedAccount),
+          ])
+        );
+
+      const tokenMints = [
+        ...new Set(
+          Object.values(parsedAccounts)
+            .map((account) => account.data.tokenMint?.toString())
+            .filter((tokenMint): tokenMint is string => tokenMint !== undefined)
+        ),
+      ].map((address) => new PublicKey(address));
+
+      const result = await metaplex
         .rpc()
-        .getMultipleAccounts(collectionPdas, commitment);
+        .getMultipleAccounts(tokenMints.concat(collectionPdas), commitment);
       scope.throwIfCanceled();
+
+      const unparsedMintAccounts = result.slice(0, tokenMints.length);
+      const unparsedCollectionAccounts = result.slice(-collectionPdas.length);
+
+      const mints: Record<string, Mint> = Object.fromEntries(
+        unparsedMintAccounts.map((account) => [
+          account.publicKey.toString(),
+          toMint(toMintAccount(account)),
+        ])
+      );
 
       return zipMap(
         unparsedAccounts,
         unparsedCollectionAccounts,
         (unparsedAccount, unparsedCollectionAccount) => {
-          const account = parseCandyMachineAccount(unparsedAccount);
+          const parsedAccount =
+            parsedAccounts[unparsedAccount.publicKey.toString()];
           const collectionAccount = unparsedCollectionAccount
             ? parseCandyMachineCollectionAccount(unparsedCollectionAccount)
             : null;
+          const tokenMintAddress = parsedAccount.data.tokenMint?.toString();
 
-          return toCandyMachine(account, unparsedAccount, collectionAccount);
+          return toCandyMachine(
+            parsedAccount,
+            unparsedAccount,
+            collectionAccount,
+            tokenMintAddress ? mints[tokenMintAddress] : null
+          );
         }
       );
     },

--- a/packages/js/test/plugins/candyMachineModule/createCandyMachine.test.ts
+++ b/packages/js/test/plugins/candyMachineModule/createCandyMachine.test.ts
@@ -4,6 +4,7 @@ import {
   CreateCandyMachineInput,
   getCandyMachineUuidFromAddress,
   sol,
+  token,
   toBigNumber,
 } from '@/index';
 import {
@@ -121,19 +122,64 @@ test('[candyMachineModule] create with creators', async (t) => {
   });
 });
 
-test('[candyMachineModule] create with SPL treasury', async (t) => {
+test('[candyMachineModule] create with 0-decimal SPL token treasury', async (t) => {
   // Given a Candy Machine client.
   const { tc, mx, client, minimalInput } = await init();
 
   // And a token account and its mint account.
-  const { token } = await mx.tokens().createTokenWithMint().run();
+  const { token: tokenMint } = await mx.tokens().createTokenWithMint().run();
+
+  const amount = token(
+    100,
+    tokenMint.mint.decimals,
+    tokenMint.mint.currency.symbol
+  );
 
   // When we create a Candy Machine with an SPL treasury.
   const { response, candyMachine } = await client
     .create({
       ...minimalInput,
-      wallet: token.address,
-      tokenMint: token.mint.address,
+      price: amount,
+      wallet: tokenMint.address,
+      tokenMint: tokenMint.mint.address,
+    })
+    .run();
+
+  // Then a Candy Machine was created with the SPL treasury as configured.
+  await tc.assertSuccess(t, response.signature);
+
+  spok(t, candyMachine, {
+    $topic: 'Candy Machine',
+    model: 'candyMachine',
+    walletAddress: spokSamePubkey(tokenMint.address),
+    tokenMintAddress: spokSamePubkey(tokenMint.mint.address),
+    price: spokSameAmount(amount),
+  } as unknown as Specifications<CandyMachine>);
+});
+
+test('[candyMachineModule] create with 9-decimal SPL token treasury', async (t) => {
+  // Given a Candy Machine client.
+  const { tc, mx, client, minimalInput } = await init();
+
+  // And a token account and its mint account.
+  const { token: tokenMint } = await mx
+    .tokens()
+    .createTokenWithMint({ decimals: 9 })
+    .run();
+
+  const amount = token(
+    1.25,
+    tokenMint.mint.decimals,
+    tokenMint.mint.currency.symbol
+  );
+
+  // When we create a Candy Machine with an SPL treasury.
+  const { response, candyMachine } = await client
+    .create({
+      ...minimalInput,
+      price: amount,
+      wallet: tokenMint.address,
+      tokenMint: tokenMint.mint.address,
     })
     .run();
 
@@ -142,8 +188,8 @@ test('[candyMachineModule] create with SPL treasury', async (t) => {
   spok(t, candyMachine, {
     $topic: 'Candy Machine',
     model: 'candyMachine',
-    walletAddress: spokSamePubkey(token.address),
-    tokenMintAddress: spokSamePubkey(token.mint.address),
+    walletAddress: spokSamePubkey(tokenMint.address),
+    tokenMintAddress: spokSamePubkey(tokenMint.mint.address),
   } as unknown as Specifications<CandyMachine>);
 });
 

--- a/packages/js/test/plugins/candyMachineModule/findCandyMachinesByPublicKeyField.test.ts
+++ b/packages/js/test/plugins/candyMachineModule/findCandyMachinesByPublicKeyField.test.ts
@@ -1,5 +1,5 @@
 import test from 'tape';
-import { killStuckProcess, metaplex } from '../../helpers';
+import { createCollectionNft, killStuckProcess, metaplex } from '../../helpers';
 import { createCandyMachine } from './helpers';
 import { Keypair } from '@solana/web3.js';
 import { token } from '@/index';
@@ -68,59 +68,94 @@ test('[candyMachineModule] find all candy machines by authority', async (t) => {
   });
 });
 
-test('[candyMachineModule] find all candy machines correctly parses token mints', async (t) => {
-  // Given two candy machines from authority A.
+test('[candyMachineModule] find all candy machines correctly parses token mints and collection addresses', async (t) => {
+  // Given three candy machines from authority A.
   const mx = await metaplex();
-  const authorityA = Keypair.generate();
+  const authority = mx.identity();
 
   const { token: token1 } = await mx.tokens().createTokenWithMint().run();
-  const { token: token2 } = await mx.tokens().createTokenWithMint().run();
+  const { token: token2_3 } = await mx.tokens().createTokenWithMint().run();
 
   const amount1 = token(1.0, token1.mint.decimals, token1.mint.currency.symbol);
-  const amount2 = token(1.5, token2.mint.decimals, token2.mint.currency.symbol);
+  const amount2 = token(
+    1.5,
+    token2_3.mint.decimals,
+    token2_3.mint.currency.symbol
+  );
+
+  const collection1 = await createCollectionNft(mx, {
+    updateAuthority: authority,
+  });
+  const collection2 = await createCollectionNft(mx, {
+    collectionAuthority: authority,
+  });
 
   const candyMachineResults = await Promise.all([
     createCandyMachine(mx, {
-      authority: authorityA.publicKey,
+      authority: authority,
       tokenMint: token1.mint.address,
       price: amount1,
       wallet: token1.address,
+      collection: collection1.address,
     }),
     createCandyMachine(mx, {
-      authority: authorityA.publicKey,
-      tokenMint: token2.mint.address,
+      authority: authority,
+      tokenMint: token2_3.mint.address,
       price: amount2,
-      wallet: token2.address,
+      wallet: token2_3.address,
+      collection: collection2.address,
     }),
     createCandyMachine(mx, {
-      authority: authorityA.publicKey,
-      tokenMint: token2.mint.address,
+      authority: authority,
+      tokenMint: token2_3.mint.address,
       price: amount2,
-      wallet: token2.address,
+      wallet: token2_3.address,
     }),
   ]);
 
   // When I find all candy machines
   const foundCandyMachines = await mx
     .candyMachines()
-    .findAllBy({ type: 'authority', publicKey: authorityA.publicKey })
+    .findAllBy({ type: 'authority', publicKey: authority.publicKey })
     .run();
 
   // Then we got three candy machines.
   t.equal(foundCandyMachines.length, 3, 'returns three accounts');
 
-  // And they had the correct token mint addresses
-  candyMachineResults.forEach((result) => {
-    const foundCandyMachine = foundCandyMachines.find((foundCandyMachine) =>
-      foundCandyMachine.address.equals(result.candyMachine.address)
-    );
-    t.ok(
-      foundCandyMachine?.tokenMintAddress &&
-        result.candyMachine.tokenMintAddress &&
-        foundCandyMachine.tokenMintAddress.equals(
-          result.candyMachine.tokenMintAddress
-        ),
-      'tokenMintAddress matches'
-    );
-  });
+  // And they maintained the correct token mint addresses and collections
+  const found1 = foundCandyMachines.find((machine) =>
+    machine.address.equals(candyMachineResults[0].candyMachine.address)
+  );
+  t.ok(
+    found1?.collectionMintAddress?.equals(collection1.address),
+    'collectionMintAddress 1 matches'
+  );
+  t.ok(
+    found1?.tokenMintAddress?.equals(token1.mint.address),
+    'tokenMintAddress 1 matches'
+  );
+
+  const found2 = foundCandyMachines.find((machine) =>
+    machine.address.equals(candyMachineResults[1].candyMachine.address)
+  );
+  t.ok(
+    found2?.collectionMintAddress?.equals(collection2.address),
+    'collectionMintAddress 2 matches'
+  );
+  t.ok(
+    found2?.tokenMintAddress?.equals(token2_3.mint.address),
+    'tokenMintAddress 2 matches'
+  );
+
+  const found3 = foundCandyMachines.find((machine) =>
+    machine.address.equals(candyMachineResults[2].candyMachine.address)
+  );
+  t.ok(
+    found3 && !found3.collectionMintAddress,
+    'collectionMintAddress 3 matches'
+  );
+  t.ok(
+    found3?.tokenMintAddress?.equals(token2_3.mint.address),
+    'tokenMintAddress 3 matches'
+  );
 });

--- a/packages/js/test/plugins/candyMachineModule/findCandyMachinesByPublicKeyField.test.ts
+++ b/packages/js/test/plugins/candyMachineModule/findCandyMachinesByPublicKeyField.test.ts
@@ -106,7 +106,7 @@ test('[candyMachineModule] find all candy machines correctly parses token mints'
     .findAllBy({ type: 'authority', publicKey: authorityA.publicKey })
     .run();
 
-  // Then we got two candy machines.
+  // Then we got three candy machines.
   t.equal(foundCandyMachines.length, 3, 'returns three accounts');
 
   // And they had the correct token mint addresses


### PR DESCRIPTION
This is a fix for #234 to handle the amounts for Candy Machine correctly when supplying arbitrary decimal SPL token treasuries.