### PR TITLE
Add optional publicKey to guestIdentity

### DIFF
--- a/packages/js/src/plugins/guestIdentity/GuestIdentityDriver.ts
+++ b/packages/js/src/plugins/guestIdentity/GuestIdentityDriver.ts
@@ -5,8 +5,8 @@ import { IdentityDriver } from '../identityModule';
 export class GuestIdentityDriver implements IdentityDriver {
   public readonly publicKey: PublicKey;
 
-  constructor() {
-    this.publicKey = PublicKey.default;
+  constructor(publicKey?: PublicKey) {
+    this.publicKey = publicKey ?? PublicKey.default;
   }
 
   public async signMessage(_message: Uint8Array): Promise<Uint8Array> {

--- a/packages/js/src/plugins/guestIdentity/plugin.ts
+++ b/packages/js/src/plugins/guestIdentity/plugin.ts
@@ -1,10 +1,11 @@
 import { Metaplex } from '@/Metaplex';
 import { MetaplexPlugin } from '@/types';
+import { PublicKey } from '@solana/web3.js';
 import { GuestIdentityDriver } from './GuestIdentityDriver';
 
 /** @group Plugins */
-export const guestIdentity = (): MetaplexPlugin => ({
+export const guestIdentity = (publicKey?: PublicKey): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
-    metaplex.identity().setDriver(new GuestIdentityDriver());
+    metaplex.identity().setDriver(new GuestIdentityDriver(publicKey));
   },
 });


### PR DESCRIPTION
This PR makes it possible to write code like this:

```ts
    const candyMachines = Metaplex
      .make(connection)
      .use(guestIdentity(somePublicKey))
```

And then have `somePublicKey` used for functions that use `metaplex.identity()`. Currently `guestIdentity()` hardcodes the default (all zeros) public key.

The change is backward compatible, the public key is just added as an optional param and defaults to the current `PublicKey.default`.

### Motivation

The concrete reason is that this enables minting NFTs from Solana Pay using this SDK, with the user as the payer. Being able to use the mint transaction builder from this SDK makes this mint code massively simpler - in a similar way that the SDK already makes custom mint UIs massively simpler.

For Solana Pay we need to write an API which takes as input a user's public key and returns a transaction for them to sign. We have no way to sign as them in this API, no connected wallet and no interactivity. This means that currently we have no way to produce a Metaplex identity for their public key: we don't have a keypair, we don't have a wallet adapter, guest identity uses the all zeros public key. We of course also have no way to produce a `Signer` for their public key. This means that currently there's no way to make them the `payer` in a candy machine mint:

```
const transactionBuilder = await metaplex
  .candyMachines()
  .builders()
    .mint({
        candyMachine,
        payer: // we're stuck,
        newOwner: somePublicKey,
      })
```

By allowing their public key to be used in `guestIdentity` we can allow `payer` to use its default `metaplex.identity()`, which will now be their public key. Of course we can't sign as them, but we don't want to - we just want them to be the expected signer in the transaction. They will sign the returned transaction in their wallet.

I've only used it with candy machine mint, but it'll work the same way for any builder that uses `metaplex.identity()`

### See also

- https://twitter.com/callum_codes/status/1568592033530654720?s=20&t=IKgQhULTQAq-6HWa2LfHrw In this thread I show how I'm using this `transactionBuilder` to create/partially sign the transaction in my API, with a keypair I control as the payer
- https://twitter.com/callum_codes/status/1568600200570085376?s=20&t=IKgQhULTQAq-6HWa2LfHrw Here I show how to set payer to the user by using a custom plugin, which is just the `guestIdentity` in this PR