### PR TITLE
Fix typo in `UninitializedWalletAdapterError`

### DIFF
--- a/packages/js/src/errors/SdkError.ts
+++ b/packages/js/src/errors/SdkError.ts
@@ -149,7 +149,7 @@ export class UninitializedWalletAdapterError extends SdkError {
       problem: 'The current wallet adapter is not initialized.',
       solution:
         'You likely have selected a wallet adapter but forgot to initialize it. ' +
-        'You may do this by running the following asynchronous method: "walletAdater.connect();".',
+        'You may do this by running the following asynchronous method: "walletAdapter.connect();".',
     });
   }
 }


### PR DESCRIPTION
Another option: renaming this to `wallet.connect()` since that's how folks have most likely called this API (`walletAdapterIdentity(wallet)`).