### PR TITLE
Add support for setting the default fee payer

### DIFF
--- a/packages/js/src/plugins/rpcModule/RpcClient.ts
+++ b/packages/js/src/plugins/rpcModule/RpcClient.ts
@@ -46,12 +46,7 @@ export type SendAndConfirmTransactionResponse = {
 export class RpcClient {
   protected defaultFeePayer?: PublicKey;
 
-  constructor(protected readonly metaplex: Metaplex) {
-    const identity = metaplex.identity().publicKey;
-    if (!identity.equals(PublicKey.default)) {
-      this.setDefaultFeePayer(identity);
-    }
-  }
+  constructor(protected readonly metaplex: Metaplex) {}
 
   async sendTransaction(
     transaction: Transaction | TransactionBuilder,
@@ -251,7 +246,12 @@ export class RpcClient {
   }
 
   getDefaultFeePayer(): PublicKey | undefined {
-    return this.defaultFeePayer;
+    if (this.defaultFeePayer) {
+      return this.defaultFeePayer;
+    }
+
+    const identity = this.metaplex.identity().publicKey;
+    return identity.equals(PublicKey.default) ? undefined : identity;
   }
 
   protected getUnparsedMaybeAccount(

--- a/packages/js/src/plugins/rpcModule/RpcClient.ts
+++ b/packages/js/src/plugins/rpcModule/RpcClient.ts
@@ -44,7 +44,14 @@ export type SendAndConfirmTransactionResponse = {
  * @group Modules
  */
 export class RpcClient {
-  constructor(protected readonly metaplex: Metaplex) {}
+  protected defaultFeePayer?: PublicKey;
+
+  constructor(protected readonly metaplex: Metaplex) {
+    const identity = metaplex.identity().publicKey;
+    if (!identity.equals(PublicKey.default)) {
+      this.setDefaultFeePayer(identity);
+    }
+  }
 
   async sendTransaction(
     transaction: Transaction | TransactionBuilder,
@@ -237,10 +244,14 @@ export class RpcClient {
     return `https://explorer.solana.com/tx/${signature}${clusterParam}`;
   }
 
-  protected getDefaultFeePayer(): PublicKey | undefined {
-    const identity = this.metaplex.identity().publicKey;
+  setDefaultFeePayer(payer: PublicKey) {
+    this.defaultFeePayer = payer;
 
-    return identity.equals(PublicKey.default) ? undefined : identity;
+    return this;
+  }
+
+  getDefaultFeePayer(): PublicKey | undefined {
+    return this.defaultFeePayer;
   }
 
   protected getUnparsedMaybeAccount(


### PR DESCRIPTION
This allows us to explicitly set the default fee payer for a Metaplex instance.

```ts
metaplex.rpc().setDefaultFeePayer(somePublicKey);
```

By default, this will still use the current identity.