### PR TITLE
Use finalized commitment before fetching data

### DIFF
--- a/packages/js-plugin-nft-storage/test/NftStorageDriver.test.ts
+++ b/packages/js-plugin-nft-storage/test/NftStorageDriver.test.ts
@@ -5,11 +5,7 @@ import { killStuckProcess, metaplex } from './helpers';
 
 killStuckProcess();
 
-// TODO(loris): Unskip these tests when we can mock the NFT Storage API.
-// Currently, these tests are hitting the real API which makes them long,
-// inconsistent and occasionally fail due to rate limiting.
-
-test.skip('[nftStorage] it can upload one file', async (t: Test) => {
+test('[nftStorage] it can upload one file', async (t: Test) => {
   // Given a Metaplex instance using NFT.Storage.
   const mx = await metaplex();
   mx.use(nftStorage());
@@ -35,7 +31,7 @@ test.skip('[nftStorage] it can upload one file', async (t: Test) => {
   );
 });
 
-test.skip('[nftStorage] it can upload one file without a Gateway URL', async (t: Test) => {
+test('[nftStorage] it can upload one file without a Gateway URL', async (t: Test) => {
   // Given a Metaplex instance using NFT.Storage without Gateway URLs.
   const mx = await metaplex();
   mx.use(nftStorage({ useGatewayUrls: false }));
@@ -50,7 +46,7 @@ test.skip('[nftStorage] it can upload one file without a Gateway URL', async (t:
   t.ok(uri.startsWith('ipfs://'), 'should use Gateway URI by default');
 });
 
-test.skip('[nftStorage] it can upload multiple files in batch', async (t: Test) => {
+test('[nftStorage] it can upload multiple files in batch', async (t: Test) => {
   // Given a Metaplex instance using NFT.Storage with a batch size of 1.
   const mx = await metaplex();
   mx.use(nftStorage({ batchSize: 1 }));
@@ -79,7 +75,7 @@ test.skip('[nftStorage] it can upload multiple files in batch', async (t: Test) 
   );
 });
 
-test.skip('[nftStorage] it can keep track of upload progress', async (t: Test) => {
+test('[nftStorage] it can keep track of upload progress', async (t: Test) => {
   // Given a Metaplex instance using NFT.Storage.
   const mx = await metaplex();
   mx.use(nftStorage());

--- a/packages/js-plugin-nft-storage/test/NftStorageDriver.test.ts
+++ b/packages/js-plugin-nft-storage/test/NftStorageDriver.test.ts
@@ -5,7 +5,11 @@ import { killStuckProcess, metaplex } from './helpers';
 
 killStuckProcess();
 
-test('[nftStorage] it can upload one file', async (t: Test) => {
+// TODO(loris): Unskip these tests when we can mock the NFT Storage API.
+// Currently, these tests are hitting the real API which makes them long,
+// inconsistent and occasionally fail due to rate limiting.
+
+test.skip('[nftStorage] it can upload one file', async (t: Test) => {
   // Given a Metaplex instance using NFT.Storage.
   const mx = await metaplex();
   mx.use(nftStorage());
@@ -31,7 +35,7 @@ test('[nftStorage] it can upload one file', async (t: Test) => {
   );
 });
 
-test('[nftStorage] it can upload one file without a Gateway URL', async (t: Test) => {
+test.skip('[nftStorage] it can upload one file without a Gateway URL', async (t: Test) => {
   // Given a Metaplex instance using NFT.Storage without Gateway URLs.
   const mx = await metaplex();
   mx.use(nftStorage({ useGatewayUrls: false }));
@@ -46,7 +50,7 @@ test('[nftStorage] it can upload one file without a Gateway URL', async (t: Test
   t.ok(uri.startsWith('ipfs://'), 'should use Gateway URI by default');
 });
 
-test('[nftStorage] it can upload multiple files in batch', async (t: Test) => {
+test.skip('[nftStorage] it can upload multiple files in batch', async (t: Test) => {
   // Given a Metaplex instance using NFT.Storage with a batch size of 1.
   const mx = await metaplex();
   mx.use(nftStorage({ batchSize: 1 }));
@@ -75,7 +79,7 @@ test('[nftStorage] it can upload multiple files in batch', async (t: Test) => {
   );
 });
 
-test('[nftStorage] it can keep track of upload progress', async (t: Test) => {
+test.skip('[nftStorage] it can keep track of upload progress', async (t: Test) => {
   // Given a Metaplex instance using NFT.Storage.
   const mx = await metaplex();
   mx.use(nftStorage());

--- a/packages/js/src/plugins/auctionHouseModule/operations/createAuctionHouse.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/createAuctionHouse.ts
@@ -169,11 +169,16 @@ export const createAuctionHouseOperationHandler: OperationHandler<CreateAuctionH
       metaplex: Metaplex,
       scope: OperationScope
     ): Promise<CreateAuctionHouseOutput> {
-      const output = await createAuctionHouseBuilder(
+      const builder = createAuctionHouseBuilder(
         metaplex,
         operation.input,
         scope
-      ).sendAndConfirm(metaplex, scope.confirmOptions);
+      );
+
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       const auctionHouse = await metaplex.auctionHouse().findByAddress(

--- a/packages/js/src/plugins/auctionHouseModule/operations/createAuctionHouse.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/createAuctionHouse.ts
@@ -11,6 +11,7 @@ import { AuctionHouse } from '../models/AuctionHouse';
 import { TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
   isSigner,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -175,10 +176,11 @@ export const createAuctionHouseOperationHandler: OperationHandler<CreateAuctionH
         scope
       );
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       const auctionHouse = await metaplex.auctionHouse().findByAddress(

--- a/packages/js/src/plugins/auctionHouseModule/operations/createBid.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/createBid.ts
@@ -15,6 +15,7 @@ import {
   amount,
   isSigner,
   lamports,
+  makeConfirmOptionsFinalizedOnMainnet,
   now,
   Operation,
   OperationHandler,
@@ -207,10 +208,11 @@ export const createBidOperationHandler: OperationHandler<CreateBidOperation> = {
     const { auctionHouse } = operation.input;
 
     const builder = await createBidBuilder(metaplex, operation.input, scope);
-    const output = await builder.sendAndConfirm(metaplex, {
-      ...scope.confirmOptions,
-      commitment: 'finalized',
-    });
+    const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+      metaplex,
+      scope.confirmOptions
+    );
+    const output = await builder.sendAndConfirm(metaplex, confirmOptions);
     scope.throwIfCanceled();
 
     if (output.receipt) {

--- a/packages/js/src/plugins/auctionHouseModule/operations/createBid.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/createBid.ts
@@ -207,7 +207,10 @@ export const createBidOperationHandler: OperationHandler<CreateBidOperation> = {
     const { auctionHouse } = operation.input;
 
     const builder = await createBidBuilder(metaplex, operation.input, scope);
-    const output = await builder.sendAndConfirm(metaplex, scope.confirmOptions);
+    const output = await builder.sendAndConfirm(metaplex, {
+      ...scope.confirmOptions,
+      commitment: 'finalized',
+    });
     scope.throwIfCanceled();
 
     if (output.receipt) {

--- a/packages/js/src/plugins/auctionHouseModule/operations/createListing.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/createListing.ts
@@ -16,6 +16,7 @@ import {
   amount,
   isSigner,
   lamports,
+  makeConfirmOptionsFinalizedOnMainnet,
   now,
   Operation,
   OperationHandler,
@@ -202,10 +203,11 @@ export const createListingOperationHandler: OperationHandler<CreateListingOperat
     ): Promise<CreateListingOutput> {
       const { auctionHouse } = operation.input;
       const builder = createListingBuilder(metaplex, operation.input, scope);
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       if (output.receipt) {

--- a/packages/js/src/plugins/auctionHouseModule/operations/createListing.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/createListing.ts
@@ -201,12 +201,11 @@ export const createListingOperationHandler: OperationHandler<CreateListingOperat
       scope: OperationScope
     ): Promise<CreateListingOutput> {
       const { auctionHouse } = operation.input;
-
-      const output = await createListingBuilder(
-        metaplex,
-        operation.input,
-        scope
-      ).sendAndConfirm(metaplex, scope.confirmOptions);
+      const builder = createListingBuilder(metaplex, operation.input, scope);
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       if (output.receipt) {

--- a/packages/js/src/plugins/candyMachineModule/operations/createCandyGuard.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/createCandyGuard.ts
@@ -12,6 +12,7 @@ import {
 import { CandyGuard } from '../models/CandyGuard';
 import { TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -146,10 +147,12 @@ export const createCandyGuardOperationHandler: OperationHandler<CreateCandyGuard
         operation.input,
         scope
       );
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       const candyGuard = await metaplex

--- a/packages/js/src/plugins/candyMachineModule/operations/createCandyGuard.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/createCandyGuard.ts
@@ -146,10 +146,10 @@ export const createCandyGuardOperationHandler: OperationHandler<CreateCandyGuard
         operation.input,
         scope
       );
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       const candyGuard = await metaplex

--- a/packages/js/src/plugins/candyMachineModule/operations/createCandyMachine.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/createCandyMachine.ts
@@ -14,6 +14,7 @@ import {
   BigNumber,
   Creator,
   isSigner,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -301,10 +302,11 @@ export const createCandyMachineOperationHandler: OperationHandler<CreateCandyMac
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       const candyMachine = await metaplex

--- a/packages/js/src/plugins/candyMachineModule/operations/createCandyMachine.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/createCandyMachine.ts
@@ -301,10 +301,10 @@ export const createCandyMachineOperationHandler: OperationHandler<CreateCandyMac
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       const candyMachine = await metaplex

--- a/packages/js/src/plugins/candyMachineModule/operations/mintFromCandyMachine.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/mintFromCandyMachine.ts
@@ -206,10 +206,10 @@ export const mintFromCandyMachineOperationHandler: OperationHandler<MintFromCand
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       let nft: NftWithToken;

--- a/packages/js/src/plugins/candyMachineModule/operations/mintFromCandyMachine.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/mintFromCandyMachine.ts
@@ -17,6 +17,7 @@ import {
 import { CandyMachine } from '../models';
 import { Option, TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -206,10 +207,11 @@ export const mintFromCandyMachineOperationHandler: OperationHandler<MintFromCand
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       let nft: NftWithToken;

--- a/packages/js/src/plugins/candyMachineV2Module/operations/createCandyMachineV2.ts
+++ b/packages/js/src/plugins/candyMachineV2Module/operations/createCandyMachineV2.ts
@@ -153,10 +153,10 @@ export const createCandyMachineV2OperationHandler: OperationHandler<CreateCandyM
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       const candyMachine = await metaplex

--- a/packages/js/src/plugins/candyMachineV2Module/operations/createCandyMachineV2.ts
+++ b/packages/js/src/plugins/candyMachineV2Module/operations/createCandyMachineV2.ts
@@ -22,6 +22,7 @@ import {
 import {
   assertSameCurrencies,
   isSigner,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -153,10 +154,11 @@ export const createCandyMachineV2OperationHandler: OperationHandler<CreateCandyM
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       const candyMachine = await metaplex

--- a/packages/js/src/plugins/candyMachineV2Module/operations/mintCandyMachineV2.ts
+++ b/packages/js/src/plugins/candyMachineV2Module/operations/mintCandyMachineV2.ts
@@ -22,6 +22,7 @@ import {
 import { TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
   assertAccountExists,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -178,10 +179,11 @@ export const mintCandyMachineV2OperationHandler: OperationHandler<MintCandyMachi
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       let nft: NftWithToken;

--- a/packages/js/src/plugins/candyMachineV2Module/operations/mintCandyMachineV2.ts
+++ b/packages/js/src/plugins/candyMachineV2Module/operations/mintCandyMachineV2.ts
@@ -178,10 +178,10 @@ export const mintCandyMachineV2OperationHandler: OperationHandler<MintCandyMachi
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       let nft: NftWithToken;

--- a/packages/js/src/plugins/nftModule/operations/createNft.ts
+++ b/packages/js/src/plugins/nftModule/operations/createNft.ts
@@ -288,7 +288,10 @@ export const createNftOperationHandler: OperationHandler<CreateNftOperation> = {
     );
     scope.throwIfCanceled();
 
-    const output = await builder.sendAndConfirm(metaplex, scope.confirmOptions);
+    const output = await builder.sendAndConfirm(metaplex, {
+      ...scope.confirmOptions,
+      commitment: 'finalized',
+    });
     scope.throwIfCanceled();
 
     const nft = await metaplex.nfts().findByMint(

--- a/packages/js/src/plugins/nftModule/operations/createNft.ts
+++ b/packages/js/src/plugins/nftModule/operations/createNft.ts
@@ -9,6 +9,7 @@ import { Option, TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
   BigNumber,
   CreatorInput,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -288,10 +289,11 @@ export const createNftOperationHandler: OperationHandler<CreateNftOperation> = {
     );
     scope.throwIfCanceled();
 
-    const output = await builder.sendAndConfirm(metaplex, {
-      ...scope.confirmOptions,
-      commitment: 'finalized',
-    });
+    const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+      metaplex,
+      scope.confirmOptions
+    );
+    const output = await builder.sendAndConfirm(metaplex, confirmOptions);
     scope.throwIfCanceled();
 
     const nft = await metaplex.nfts().findByMint(

--- a/packages/js/src/plugins/nftModule/operations/createSft.ts
+++ b/packages/js/src/plugins/nftModule/operations/createSft.ts
@@ -317,7 +317,10 @@ export const createSftOperationHandler: OperationHandler<CreateSftOperation> = {
     );
     scope.throwIfCanceled();
 
-    const output = await builder.sendAndConfirm(metaplex, scope.confirmOptions);
+    const output = await builder.sendAndConfirm(metaplex, {
+      ...scope.confirmOptions,
+      commitment: 'finalized',
+    });
     scope.throwIfCanceled();
 
     const sft = await metaplex.nfts().findByMint(

--- a/packages/js/src/plugins/nftModule/operations/createSft.ts
+++ b/packages/js/src/plugins/nftModule/operations/createSft.ts
@@ -10,6 +10,7 @@ import {
   Creator,
   CreatorInput,
   isSigner,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -317,10 +318,11 @@ export const createSftOperationHandler: OperationHandler<CreateSftOperation> = {
     );
     scope.throwIfCanceled();
 
-    const output = await builder.sendAndConfirm(metaplex, {
-      ...scope.confirmOptions,
-      commitment: 'finalized',
-    });
+    const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+      metaplex,
+      scope.confirmOptions
+    );
+    const output = await builder.sendAndConfirm(metaplex, confirmOptions);
     scope.throwIfCanceled();
 
     const sft = await metaplex.nfts().findByMint(

--- a/packages/js/src/plugins/nftModule/operations/printNewEdition.ts
+++ b/packages/js/src/plugins/nftModule/operations/printNewEdition.ts
@@ -10,6 +10,7 @@ import {
 import { TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
   BigNumber,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -165,10 +166,11 @@ export const printNewEditionOperationHandler: OperationHandler<PrintNewEditionOp
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       const nft = await metaplex.nfts().findByMint(

--- a/packages/js/src/plugins/nftModule/operations/printNewEdition.ts
+++ b/packages/js/src/plugins/nftModule/operations/printNewEdition.ts
@@ -165,10 +165,10 @@ export const printNewEditionOperationHandler: OperationHandler<PrintNewEditionOp
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       const nft = await metaplex.nfts().findByMint(

--- a/packages/js/src/plugins/tokenModule/operations/createMint.ts
+++ b/packages/js/src/plugins/tokenModule/operations/createMint.ts
@@ -109,10 +109,10 @@ export const createMintOperationHandler: OperationHandler<CreateMintOperation> =
       const builder = await createMintBuilder(metaplex, operation.input, scope);
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       const mint = await metaplex

--- a/packages/js/src/plugins/tokenModule/operations/createMint.ts
+++ b/packages/js/src/plugins/tokenModule/operations/createMint.ts
@@ -4,6 +4,7 @@ import { SendAndConfirmTransactionResponse } from '../../rpcModule';
 import { Mint } from '../models/Mint';
 import { Option, TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -109,10 +110,11 @@ export const createMintOperationHandler: OperationHandler<CreateMintOperation> =
       const builder = await createMintBuilder(metaplex, operation.input, scope);
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       const mint = await metaplex

--- a/packages/js/src/plugins/tokenModule/operations/createToken.ts
+++ b/packages/js/src/plugins/tokenModule/operations/createToken.ts
@@ -106,10 +106,10 @@ export const createTokenOperationHandler: OperationHandler<CreateTokenOperation>
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       const token = await metaplex

--- a/packages/js/src/plugins/tokenModule/operations/createToken.ts
+++ b/packages/js/src/plugins/tokenModule/operations/createToken.ts
@@ -10,6 +10,7 @@ import { ExpectedSignerError } from '@/errors';
 import type { Metaplex } from '@/Metaplex';
 import {
   isSigner,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -106,10 +107,11 @@ export const createTokenOperationHandler: OperationHandler<CreateTokenOperation>
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       const token = await metaplex

--- a/packages/js/src/plugins/tokenModule/operations/createTokenWithMint.ts
+++ b/packages/js/src/plugins/tokenModule/operations/createTokenWithMint.ts
@@ -5,6 +5,7 @@ import { TokenWithMint } from '../models/Token';
 import { Option, TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
   isSigner,
+  makeConfirmOptionsFinalizedOnMainnet,
   Operation,
   OperationHandler,
   OperationScope,
@@ -144,10 +145,11 @@ export const createTokenWithMintOperationHandler: OperationHandler<CreateTokenWi
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(metaplex, {
-        ...scope.confirmOptions,
-        commitment: 'finalized',
-      });
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
       scope.throwIfCanceled();
 
       const token = await metaplex.tokens().findTokenWithMintByMint(

--- a/packages/js/src/plugins/tokenModule/operations/createTokenWithMint.ts
+++ b/packages/js/src/plugins/tokenModule/operations/createTokenWithMint.ts
@@ -144,10 +144,10 @@ export const createTokenWithMintOperationHandler: OperationHandler<CreateTokenWi
       );
       scope.throwIfCanceled();
 
-      const output = await builder.sendAndConfirm(
-        metaplex,
-        scope.confirmOptions
-      );
+      const output = await builder.sendAndConfirm(metaplex, {
+        ...scope.confirmOptions,
+        commitment: 'finalized',
+      });
       scope.throwIfCanceled();
 
       const token = await metaplex.tokens().findTokenWithMintByMint(

--- a/packages/js/src/types/Operation.ts
+++ b/packages/js/src/types/Operation.ts
@@ -132,3 +132,12 @@ export const useOperation = <
 
   return constructor;
 };
+
+export const makeConfirmOptionsFinalizedOnMainnet = (
+  metaplex: Metaplex,
+  options?: ConfirmOptions
+): ConfirmOptions | undefined => {
+  return metaplex.cluster === 'mainnet-beta'
+    ? { ...options, commitment: 'finalized' }
+    : options;
+};


### PR DESCRIPTION
This PR forces the use of the `finalized` commitment on the `mainnet-beta` cluster only for write operations that create and return accounts.

This is because, otherwise, we may reach a "race condition" where we are trying to fetch an account before the transaction is finalized and propagated to the blockchain.

This only needs to happen on write operations that create accounts since it is the only scenario where the SDK writes to and reads from the blockchain simultaneously. That is when:
- creating NFTs, SFTs and printing edition NFTs.
- Creating Candy Machines and Candy Guards.
- Creating Tokens, Mints and TokenWithMints.
- Creating Auction Houses, Listings and Bids.

See #330 