### PR TITLE
Fix `Buffer` related error in browsers

### DIFF
--- a/packages/js/src/plugins/candyMachineModule/models/CandyMachine.ts
+++ b/packages/js/src/plugins/candyMachineModule/models/CandyMachine.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import {
   CandyMachine as MplCandyMachine,
   candyMachineBeet,

--- a/packages/js/src/plugins/candyMachineModule/models/CandyMachine.ts
+++ b/packages/js/src/plugins/candyMachineModule/models/CandyMachine.ts
@@ -389,7 +389,7 @@ export const toCandyMachine = <
     isFullyLoaded,
     itemSettings,
     featureFlags: deserializeFeatureFlags(
-      toBigNumber(parsedAccount.data.features).toBuffer('le', 8),
+      toBigNumber(parsedAccount.data.features).toArrayLike(Buffer, 'le', 8),
       64
     )[0],
     candyGuard,


### PR DESCRIPTION
Using `toArrayLike` instead of `toBuffer` solves the error in #346.

`bn.js` mentions this on `toBuffer`:
```
For compatibility with browserify and similar tools, use this instead: a.toArrayLike(Buffer, endian, length)
```

Closes #346 