### PR TITLE
Use appropriate payers in derived identity

### DIFF
--- a/packages/js/src/plugins/derivedIdentity/DerivedIdentityClient.ts
+++ b/packages/js/src/plugins/derivedIdentity/DerivedIdentityClient.ts
@@ -59,20 +59,26 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
 
   fund(amount: SolAmount) {
     this.assertInitialized();
-    return this.metaplex.system().transferSol({
-      from: this.originalSigner,
-      to: this.derivedKeypair.publicKey,
-      amount,
-    });
+    return this.metaplex.system().transferSol(
+      {
+        from: this.originalSigner,
+        to: this.derivedKeypair.publicKey,
+        amount,
+      },
+      { payer: this.originalSigner }
+    );
   }
 
   withdraw(amount: SolAmount) {
     this.assertInitialized();
-    return this.metaplex.system().transferSol({
-      from: this.derivedKeypair,
-      to: this.originalSigner.publicKey,
-      amount,
-    });
+    return this.metaplex.system().transferSol(
+      {
+        from: this.derivedKeypair,
+        to: this.originalSigner.publicKey,
+        amount,
+      },
+      { payer: this.derivedKeypair }
+    );
   }
 
   async withdrawAll() {

--- a/packages/js/src/plugins/utilsModule/UtilsClient.ts
+++ b/packages/js/src/plugins/utilsModule/UtilsClient.ts
@@ -44,6 +44,8 @@ export class UtilsClient {
       this.cachedRentPerByte === null
     ) {
       const rentFor0Bytes = await this.metaplex.rpc().getRent(0);
+
+      // TODO(loris): Infer from header size in bytes.
       const rentFor1Byte = await this.metaplex.rpc().getRent(1);
       this.cachedRentPerEmptyAccount = rentFor0Bytes;
       this.cachedRentPerByte = subtractAmounts(rentFor1Byte, rentFor0Bytes);


### PR DESCRIPTION
Ensures that the transaction fee payers when funding to or withdrawing from the derived identity are set to the source accounts.