### PR TITLE
Documentation Error 'The amount of tokens to (mint -> send)'

### DIFF
--- a/packages/js/src/plugins/tokenModule/operations/sendTokens.ts
+++ b/packages/js/src/plugins/tokenModule/operations/sendTokens.ts
@@ -57,7 +57,7 @@ export type SendTokensInput = {
   /** The address of the mint account. */
   mintAddress: PublicKey;
 
-  /** The amount of tokens to mint. */
+  /** The amount of tokens to send. */
   amount: SplTokenAmount;
 
   /**


### PR DESCRIPTION
The amount in the context of sendTokens should be amount to 'send' not amount to 'mint'