### PR TITLE
feat: efficient findNftsBy methods by reducing RPC calls

### DIFF
--- a/packages/js/src/plugins/nftModule/operations/findNftsByUpdateAuthority.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftsByUpdateAuthority.ts
@@ -1,6 +1,7 @@
 import { PublicKey } from '@solana/web3.js';
+import { toMetadataAccount } from '../accounts';
 import { MetadataV1GpaBuilder } from '../gpaBuilders';
-import { Metadata, Nft, Sft } from '../models';
+import { Metadata, Nft, Sft, toMetadata } from '../models';
 import {
   Operation,
   OperationHandler,
@@ -73,15 +74,21 @@ export const findNftsByUpdateAuthorityOperationHandler: OperationHandler<FindNft
         metaplex.programs().getTokenMetadata(scope.programs).address
       );
 
-      const mints = await gpaBuilder
-        .selectMint()
-        .whereUpdateAuthority(updateAuthority)
-        .getDataAsPublicKeys();
+      const nfts = await gpaBuilder.whereUpdateAuthority(updateAuthority).get();
       scope.throwIfCanceled();
 
-      const nfts = await metaplex.nfts().findAllByMintList({ mints }, scope);
-      scope.throwIfCanceled();
+      return nfts
+        .map<Metadata | null>((account) => {
+          if (account == null) {
+            return null;
+          }
 
-      return nfts.filter((nft): nft is Metadata | Nft | Sft => nft !== null);
+          try {
+            return toMetadata(toMetadataAccount(account));
+          } catch (error) {
+            return null;
+          }
+        })
+        .filter((nft): nft is Metadata => nft !== null);
     },
   };


### PR DESCRIPTION
Both `findNftsByCreator()` and `findNftsByUpdateAuthority()` first fetch the nft mints, then make a call to `findAllByMintList()`.

https://github.com/metaplex-foundation/js/blob/8dcccc0a40938170db12827974552e66b47b84b9/packages/js/src/plugins/nftModule/operations/findNftsByCreator.ts#L92-L98

https://github.com/metaplex-foundation/js/blob/8dcccc0a40938170db12827974552e66b47b84b9/packages/js/src/plugins/nftModule/operations/findNftsByUpdateAuthority.ts#L76-L82

This is unnecessary since the `getProgramAccounts()` call returns all the needed data.
This PR allows parsing that data instead of making additonal RPC calls.