### PR TITLE
Add support for updating the Candy Guard authority

### DIFF
--- a/packages/js/src/plugins/candyMachineModule/CandyMachineBuildersClient.ts
+++ b/packages/js/src/plugins/candyMachineModule/CandyMachineBuildersClient.ts
@@ -30,6 +30,10 @@ import {
   wrapCandyGuardBuilder,
   WrapCandyGuardBuilderParams,
 } from './operations';
+import {
+  updateCandyGuardAuthorityBuilder,
+  UpdateCandyGuardAuthorityBuilderParams,
+} from './operations/updateCandyGuardAuthority';
 import type { Metaplex } from '@/Metaplex';
 import { TransactionBuilderOptions } from '@/utils';
 
@@ -128,6 +132,14 @@ export class CandyMachineBuildersClient {
     options?: TransactionBuilderOptions
   ) {
     return updateCandyGuardBuilder(this.metaplex, input, options);
+  }
+
+  /** {@inheritDoc updateCandyGuardAuthorityBuilder} */
+  updateCandyGuardAuthority(
+    input: UpdateCandyGuardAuthorityBuilderParams,
+    options?: TransactionBuilderOptions
+  ) {
+    return updateCandyGuardAuthorityBuilder(this.metaplex, input, options);
   }
 
   /** {@inheritDoc wrapCandyGuardBuilder} */

--- a/packages/js/src/plugins/candyMachineModule/CandyMachineClient.ts
+++ b/packages/js/src/plugins/candyMachineModule/CandyMachineClient.ts
@@ -40,6 +40,10 @@ import {
   WrapCandyGuardInput,
   wrapCandyGuardOperation,
 } from './operations';
+import {
+  UpdateCandyGuardAuthorityInput,
+  updateCandyGuardAuthorityOperation,
+} from './operations/updateCandyGuardAuthority';
 import { OperationOptions, toPublicKey } from '@/types';
 import type { Metaplex } from '@/Metaplex';
 
@@ -297,6 +301,16 @@ export class CandyMachineClient {
     return this.metaplex
       .operations()
       .execute(updateCandyGuardOperation(input), options);
+  }
+
+  /** {@inheritDoc updateCandyGuardAuthorityOperation} */
+  updateCandyGuardAuthority(
+    input: UpdateCandyGuardAuthorityInput,
+    options?: OperationOptions
+  ) {
+    return this.metaplex
+      .operations()
+      .execute(updateCandyGuardAuthorityOperation(input), options);
   }
 
   /** {@inheritDoc wrapCandyGuardOperation} */

--- a/packages/js/src/plugins/candyMachineModule/operations/updateCandyGuardAuthority.ts
+++ b/packages/js/src/plugins/candyMachineModule/operations/updateCandyGuardAuthority.ts
@@ -1,0 +1,153 @@
+import { createSetAuthorityInstruction } from '@metaplex-foundation/mpl-candy-guard';
+import type { PublicKey } from '@solana/web3.js';
+import { SendAndConfirmTransactionResponse } from '../../rpcModule';
+import { Metaplex } from '@/Metaplex';
+import {
+  Operation,
+  OperationHandler,
+  OperationScope,
+  Signer,
+  useOperation,
+} from '@/types';
+import { TransactionBuilder, TransactionBuilderOptions } from '@/utils';
+
+// -----------------
+// Operation
+// -----------------
+
+const Key = 'UpdateCandyGuardAuthorityOperation' as const;
+
+/**
+ * Updates the authority of a Candy Guard account.
+ *
+ * ```ts
+ * await metaplex
+ *   .candyMachines()
+ *   .updateCandyGuardAuthority({
+ *     candyGuard: candyGuard.address,
+ *     authority: candyGuardAuthority,
+ *     newAuthority,
+ *   };
+ * ```
+ *
+ * @group Operations
+ * @category Constructors
+ */
+export const updateCandyGuardAuthorityOperation =
+  useOperation<UpdateCandyGuardAuthorityOperation>(Key);
+
+/**
+ * @group Operations
+ * @category Types
+ */
+export type UpdateCandyGuardAuthorityOperation = Operation<
+  typeof Key,
+  UpdateCandyGuardAuthorityInput,
+  UpdateCandyGuardAuthorityOutput
+>;
+
+/**
+ * @group Operations
+ * @category Inputs
+ */
+export type UpdateCandyGuardAuthorityInput = {
+  /** The address of the Candy Guard to update. */
+  candyGuard: PublicKey;
+
+  /**
+   * The Signer authorized to update the candy Guard.
+   *
+   * @defaultValue `metaplex.identity()`
+   */
+  authority?: Signer;
+
+  /** The address of the new authority. */
+  newAuthority: PublicKey;
+};
+
+/**
+ * @group Operations
+ * @category Outputs
+ */
+export type UpdateCandyGuardAuthorityOutput = {
+  /** The blockchain response from sending and confirming the transaction. */
+  response: SendAndConfirmTransactionResponse;
+};
+
+/**
+ * @group Operations
+ * @category Handlers
+ */
+export const updateCandyGuardAuthorityOperationHandler: OperationHandler<UpdateCandyGuardAuthorityOperation> =
+  {
+    async handle(
+      operation: UpdateCandyGuardAuthorityOperation,
+      metaplex: Metaplex,
+      scope: OperationScope
+    ): Promise<UpdateCandyGuardAuthorityOutput> {
+      return updateCandyGuardAuthorityBuilder(
+        metaplex,
+        operation.input,
+        scope
+      ).sendAndConfirm(metaplex, scope.confirmOptions);
+    },
+  };
+
+// -----------------
+// Builder
+// -----------------
+
+/**
+ * @group Transaction Builders
+ * @category Inputs
+ */
+export type UpdateCandyGuardAuthorityBuilderParams = Omit<
+  UpdateCandyGuardAuthorityInput,
+  'confirmOptions'
+> & {
+  /** A key to distinguish the instruction that updates the candy guard. */
+  instructionKey?: string;
+};
+
+/**
+ * Updates the authority of a Candy Guard account.
+ *
+ * ```ts
+ * await metaplex
+ *   .candyMachines()
+ *   .builders()
+ *   .updateCandyGuardAuthority({
+ *     candyGuard: candyGuard.address,
+ *     authority: candyGuardAuthority,
+ *     newAuthority,
+ *   };
+ * ```
+ *
+ * @group Transaction Builders
+ * @category Constructors
+ */
+export const updateCandyGuardAuthorityBuilder = (
+  metaplex: Metaplex,
+  params: UpdateCandyGuardAuthorityBuilderParams,
+  options: TransactionBuilderOptions = {}
+): TransactionBuilder => {
+  const { programs, payer = metaplex.rpc().getDefaultFeePayer() } = options;
+  const { candyGuard, newAuthority, authority = metaplex.identity() } = params;
+  const candyGuardProgram = metaplex.programs().getCandyGuard(programs);
+
+  return (
+    TransactionBuilder.make()
+      .setFeePayer(payer)
+
+      // Update the candy guard account.
+      .add({
+        instruction: createSetAuthorityInstruction(
+          { candyGuard, authority: authority.publicKey },
+          { newAuthority },
+          candyGuardProgram.address
+        ),
+        signers: [authority, payer],
+        key: params.instructionKey ?? 'updateCandyGuardAuthority',
+      })
+  );
+};

--- a/packages/js/src/plugins/candyMachineModule/plugin.ts
+++ b/packages/js/src/plugins/candyMachineModule/plugin.ts
@@ -55,6 +55,10 @@ import {
   defaultCandyGuardProgram,
   gatewayProgram,
 } from './programs';
+import {
+  updateCandyGuardAuthorityOperation,
+  updateCandyGuardAuthorityOperationHandler,
+} from './operations/updateCandyGuardAuthority';
 import { MetaplexPlugin, OperationConstructor, Program } from '@/types';
 import type { Metaplex } from '@/Metaplex';
 
@@ -149,6 +153,10 @@ export const candyMachineModule = (): MetaplexPlugin => ({
       mintFromCandyMachineOperationHandler
     );
     op.register(unwrapCandyGuardOperation, unwrapCandyGuardOperationHandler);
+    op.register(
+      updateCandyGuardAuthorityOperation,
+      updateCandyGuardAuthorityOperationHandler
+    );
     op.register(updateCandyGuardOperation, updateCandyGuardOperationHandler);
     op.register(
       updateCandyMachineOperation,

--- a/packages/js/test/plugins/candyMachineModule/updateCandyGuardAuthority.test.ts
+++ b/packages/js/test/plugins/candyMachineModule/updateCandyGuardAuthority.test.ts
@@ -1,0 +1,30 @@
+import { Keypair } from '@solana/web3.js';
+import test from 'tape';
+import { killStuckProcess, metaplex } from '../../helpers';
+import { createCandyGuard } from './helpers';
+
+killStuckProcess();
+
+test('[candyMachineModule] it can update the authority of a Candy Guard account', async (t) => {
+  // Given a Candy Guard account with an old authority.
+  const mx = await metaplex();
+  const oldAuthority = Keypair.generate();
+  const candyGuard = await createCandyGuard(mx, {
+    authority: oldAuthority.publicKey,
+  });
+
+  // When we update its authority.
+  const newAuthority = Keypair.generate();
+  await mx.candyMachines().updateCandyGuardAuthority({
+    candyGuard: candyGuard.address,
+    authority: oldAuthority,
+    newAuthority: newAuthority.publicKey,
+  });
+
+  // Then the updated Candy Guard has the expected data.
+  const updatedCandyGuard = await mx.candyMachines().refresh(candyGuard);
+  t.ok(
+    updatedCandyGuard.authorityAddress.equals(newAuthority.publicKey),
+    'The authority is updated'
+  );
+});

--- a/packages/js/test/plugins/candyMachineModule/updateCandyMachine.test.ts
+++ b/packages/js/test/plugins/candyMachineModule/updateCandyMachine.test.ts
@@ -361,6 +361,65 @@ test('[candyMachineModule] it can update the mint authority of a candy machine',
   } as unknown as Specifications<CandyMachine>);
 });
 
+test('[candyMachineModule] it can update the authority of a candy guard', async (t) => {
+  // Given a Candy Machine and its Candy Guard using authority A.
+  const mx = await metaplex();
+  const authorityA = Keypair.generate();
+  const { candyMachine } = await createCandyMachine(mx, {
+    authority: authorityA,
+  });
+
+  // When we update the Candy Guard account to use authority B.
+  const authorityB = Keypair.generate();
+  await mx.candyMachines().update({
+    candyMachine,
+    candyGuardAuthority: authorityA,
+    newCandyGuardAuthority: authorityB.publicKey,
+  });
+
+  // Then the Candy Guard's authority was updated accordingly.
+  const updatedCandyMachine = await mx.candyMachines().refresh(candyMachine);
+  const updatedCandyGuard = updatedCandyMachine.candyGuard!;
+  t.ok(
+    updatedCandyMachine.authorityAddress.equals(authorityA.publicKey),
+    'Candy Machine authority was not updated'
+  );
+  t.ok(
+    updatedCandyGuard.authorityAddress.equals(authorityB.publicKey),
+    'Candy Guard authority was updated'
+  );
+});
+
+test('[candyMachineModule] it can update both the authority and the candy guard authority of a candy machine', async (t) => {
+  // Given a Candy Machine and its Candy Guard using authority A.
+  const mx = await metaplex();
+  const authorityA = Keypair.generate();
+  const { candyMachine } = await createCandyMachine(mx, {
+    authority: authorityA,
+  });
+
+  // When we update both authorities to authority B.
+  const authorityB = Keypair.generate();
+  await mx.candyMachines().update({
+    candyMachine,
+    authority: authorityA,
+    newAuthority: authorityB.publicKey,
+    newCandyGuardAuthority: authorityB.publicKey,
+  });
+
+  // Then the both the candy machine and the candy guard were updated accordingly.
+  const updatedCandyMachine = await mx.candyMachines().refresh(candyMachine);
+  const updatedCandyGuard = updatedCandyMachine.candyGuard!;
+  t.ok(
+    updatedCandyMachine.authorityAddress.equals(authorityB.publicKey),
+    'Candy Machine authority was updated'
+  );
+  t.ok(
+    updatedCandyGuard.authorityAddress.equals(authorityB.publicKey),
+    'Candy Guard authority was updated'
+  );
+});
+
 test('[candyMachineModule] it can update the collection of a candy machine', async (t) => {
   // Given a Candy Machine associated to Collection A.
   const mx = await metaplex();


### PR DESCRIPTION
- Adds a `updateCandyGuardAuthority` operation
- Updates the `updateCandyMachine` operation by adding a `newCandyGuardAuthority` parameter.