### PR TITLE
Return Metadata with Token from findNftsByOwner

### DIFF
--- a/packages/js/src/plugins/nftModule/models/Metadata.ts
+++ b/packages/js/src/plugins/nftModule/models/Metadata.ts
@@ -194,3 +194,20 @@ export const toMetadata = (
 
 /** @group Models */
 export type MetadataWithToken = Metadata & { token: Token };
+
+/** @group Model Helpers */
+export const isMetadataWithToken = (value: any): value is MetadataWithToken =>
+  isMetadata(value) && 'token' in value;
+
+/** @group Model Helpers */
+export function assertMetadataWithToken(value: any): asserts value is MetadataWithToken {
+  assert(isMetadataWithToken(value), `Expected Metadata model with token`);
+}
+
+/** @group Model Helpers */
+export const toMetadataWithToken = (
+  metadata: Metadata,
+  token: Token
+): MetadataWithToken => ({
+  ...metadata, token
+});

--- a/packages/js/src/plugins/nftModule/models/Metadata.ts
+++ b/packages/js/src/plugins/nftModule/models/Metadata.ts
@@ -209,5 +209,17 @@ export const toMetadataWithToken = (
   metadata: Metadata,
   token: Token
 ): MetadataWithToken => ({
-  ...metadata, token
+  ...metadata, token: {
+    ...token,
+    amount: {
+      ...token.amount, currency: {
+        ...token.amount.currency, symbol: metadata.symbol || 'Token'
+      }
+    },
+    delegateAmount: {
+      ...token.delegateAmount, currency: {
+        ...token.delegateAmount.currency, symbol: metadata.symbol || 'Token'
+      }
+    }
+  }
 });

--- a/packages/js/src/plugins/nftModule/models/Metadata.ts
+++ b/packages/js/src/plugins/nftModule/models/Metadata.ts
@@ -7,6 +7,7 @@ import { MetadataAccount } from '../accounts';
 import { JsonMetadata } from './JsonMetadata';
 import { assert, Option, removeEmptyChars } from '@/utils';
 import { BigNumber, Creator, Pda, toBigNumber } from '@/types';
+import type { Token } from '../../tokenModule';
 
 /** @group Models */
 export type Metadata<Json extends object = JsonMetadata> = {
@@ -190,3 +191,6 @@ export const toMetadata = (
       }
     : null,
 });
+
+/** @group Models */
+export type MetadataWithToken = Metadata & { token: Token };

--- a/packages/js/src/plugins/nftModule/operations/findNftsByCreator.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftsByCreator.ts
@@ -92,6 +92,7 @@ export const findNftsByCreatorOperationHandler: OperationHandler<FindNftsByCreat
 
       const nfts = await gpaBuilder.whereCreator(position, creator).get();
       scope.throwIfCanceled();
+      //a
 
       return nfts
         .map<Metadata | null>((account) => {

--- a/packages/js/src/plugins/nftModule/operations/findNftsByCreator.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftsByCreator.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from '@solana/web3.js';
 import { toMetadataAccount } from '../accounts';
 import { MetadataV1GpaBuilder } from '../gpaBuilders';
-import { Metadata, Nft, Sft, toMetadata } from '../models';
+import { Metadata, toMetadata } from '../models';
 import {
   Operation,
   OperationHandler,
@@ -69,7 +69,7 @@ export type FindNftsByCreatorInput = {
  * @group Operations
  * @category Outputs
  */
-export type FindNftsByCreatorOutput = (Metadata | Nft | Sft)[];
+export type FindNftsByCreatorOutput = Metadata[];
 
 /**
  * @group Operations
@@ -92,7 +92,6 @@ export const findNftsByCreatorOperationHandler: OperationHandler<FindNftsByCreat
 
       const nfts = await gpaBuilder.whereCreator(position, creator).get();
       scope.throwIfCanceled();
-      //a
 
       return nfts
         .map<Metadata | null>((account) => {

--- a/packages/js/src/plugins/nftModule/operations/findNftsByMintList.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftsByMintList.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
 import { toMetadataAccount } from '../accounts';
-import { Metadata, Nft, Sft, toMetadata } from '../models';
+import { Metadata, toMetadata } from '../models';
 import { Metaplex } from '@/Metaplex';
 import {
   Operation,
@@ -54,7 +54,7 @@ export type FindNftsByMintListInput = {
  * @group Operations
  * @category Outputs
  */
-export type FindNftsByMintListOutput = (Metadata | Nft | Sft | null)[];
+export type FindNftsByMintListOutput = Metadata[];
 
 /**
  * @group Operations
@@ -88,6 +88,7 @@ export const findNftsByMintListOperationHandler: OperationHandler<FindNftsByMint
         } catch (error) {
           return null;
         }
-      });
+      })
+      .filter((nft): nft is Metadata => nft !== null);
     },
   };

--- a/packages/js/src/plugins/nftModule/operations/findNftsByOwner.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftsByOwner.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
 import { Token, TokenGpaBuilder, toToken, toTokenAccount } from '../../tokenModule';
-import { Metadata, MetadataWithToken } from '../models';
+import { Metadata, MetadataWithToken, toMetadataWithToken } from '../models';
 import {
   Operation,
   OperationHandler,
@@ -79,9 +79,9 @@ export const findNftsByOwnerOperationHandler: OperationHandler<FindNftsByOwnerOp
       const nfts = await metaplex.nfts().findAllByMintList({ mints: tokenAccounts.map(tokenAccount => tokenAccount.mintAddress) }, scope);
       scope.throwIfCanceled();
 
-      return nfts.filter((nft): nft is Metadata => nft !== null ).map((nft) => {
-        const token = tokenAccounts.find(tokenAccount => tokenAccount.mintAddress.toBase58() === nft.mintAddress.toBase58())!
-        return {...nft, token}
+      return nfts.filter((nft): nft is Metadata => nft !== null ).map((metadata) => {
+        const token = tokenAccounts.find(tokenAccount => tokenAccount.mintAddress.toBase58() === metadata.mintAddress.toBase58())!
+        return toMetadataWithToken(metadata, token)
       });
     },
   };

--- a/packages/js/src/plugins/nftModule/operations/findNftsByOwner.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftsByOwner.ts
@@ -53,7 +53,7 @@ export type FindNftsByOwnerInput = {
  * @group Operations
  * @category Outputs
  */
-export type FindNftsByOwnerOutput = (MetadataWithToken)[];
+export type FindNftsByOwnerOutput = MetadataWithToken[];
 
 /**
  * @group Operations

--- a/packages/js/src/plugins/nftModule/operations/findNftsByOwner.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftsByOwner.ts
@@ -70,19 +70,11 @@ export const findNftsByOwnerOperationHandler: OperationHandler<FindNftsByOwnerOp
       const { owner } = operation.input;
 
       const tokenProgram = metaplex.programs().getToken(programs);
-      const tokenAccountsUnparsed = await new TokenGpaBuilder(metaplex, tokenProgram.address)
+      const tokenAccounts: Token[] = await new TokenGpaBuilder(metaplex, tokenProgram.address)
         .whereOwner(owner)
         .whereAmount(1)
-        .get();
+        .getAndMap(tokenAccount => toToken(toTokenAccount(tokenAccount)));
       scope.throwIfCanceled();
-
-      const tokenAccounts = tokenAccountsUnparsed.map(tokenAccount => {
-        try {
-          return toToken(toTokenAccount(tokenAccount))
-        } catch (error) {
-          return null
-        }
-      }).filter((tokenAccount): tokenAccount is Token => tokenAccount !== null);
 
       const nfts = await metaplex.nfts().findAllByMintList({ mints: tokenAccounts.map(tokenAccount => tokenAccount.mintAddress) }, scope);
       scope.throwIfCanceled();

--- a/packages/js/src/plugins/nftModule/operations/findNftsByUpdateAuthority.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftsByUpdateAuthority.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from '@solana/web3.js';
 import { toMetadataAccount } from '../accounts';
 import { MetadataV1GpaBuilder } from '../gpaBuilders';
-import { Metadata, Nft, Sft, toMetadata } from '../models';
+import { Metadata, toMetadata } from '../models';
 import {
   Operation,
   OperationHandler,
@@ -54,7 +54,7 @@ export type FindNftsByUpdateAuthorityInput = {
  * @group Operations
  * @category Outputs
  */
-export type FindNftsByUpdateAuthorityOutput = (Metadata | Nft | Sft)[];
+export type FindNftsByUpdateAuthorityOutput = Metadata[];
 
 /**
  * @group Operations

--- a/packages/js/test/plugins/nftModule/findNftsByOwner.test.ts
+++ b/packages/js/test/plugins/nftModule/findNftsByOwner.test.ts
@@ -1,6 +1,6 @@
 import test, { Test } from 'tape';
 import { metaplex, createNft, killStuckProcess } from '../../helpers';
-import { Metadata } from '@/index';
+import { MetadataWithToken } from '@/index';
 
 killStuckProcess();
 
@@ -14,7 +14,7 @@ test('[nftModule] it can fetch all NFTs in a wallet', async (t: Test) => {
   const nftB = await createNft(mx, { name: 'NFT B' });
 
   // When we fetch all NFTs in the wallet.
-  const nfts = (await mx.nfts().findAllByOwner({ owner })) as Metadata[];
+  const nfts = (await mx.nfts().findAllByOwner({ owner })) as MetadataWithToken[];
 
   // Then we get the right NFTs.
   t.same(nfts.map((nft) => nft.name).sort(), ['NFT A', 'NFT B']);
@@ -22,4 +22,10 @@ test('[nftModule] it can fetch all NFTs in a wallet', async (t: Test) => {
     nfts.map((nft) => nft.mintAddress.toBase58()).sort(),
     [nftA.address.toBase58(), nftB.address.toBase58()].sort()
   );
+
+  // With the corresponding token account.
+  t.same(
+    nfts.map((nft) => nft.token.address.toBase58()).sort(),
+    [nftA.token.address.toBase58(), nftB.token.address.toBase58()].sort()
+  )
 });


### PR DESCRIPTION
Reason: findNftsByOwner operation starts with retrieving all Token Accounts of provided owner. Having TAs we could easily retrieve Token model from them. But the operation is slicing data to keep only mintAddress from TA.

Change: instead of slicing TA data, keep full TA data and retrieve Token model from it. Add MetadataWithToken model and return it instead of Metadata. Also operation Output type was (Metadata | Nft | Sft | null)[] but in fact it could be only Metadata[] (after changes - MetadataWithToken[])

Usecase: now findNftsByOwner operation is enough to construct some instructions, for example transfer instruction without need to additionally search for TA again. Delegate amount checks also accessible just from findNftsByOwner operation result. Etc.