### PR TITLE
Add Retries to findByMint call in CreateNFT operation

### DIFF
--- a/packages/js/src/utils/RetryBuilder.ts
+++ b/packages/js/src/utils/RetryBuilder.ts
@@ -1,0 +1,47 @@
+import { Metaplex } from '@/Metaplex';
+
+export type RetryOptions = {
+  function: (...args: any[]) => any,
+  parameters?: any[],
+  numRetries?: number,
+  timeout?: number
+};
+
+export class RetryBuilder {
+  protected fn: (...args: any[]) => any;
+  protected parameters?: any[];
+  protected numRetries?: number;
+  protected timeout?: number;
+  protected result?: any;
+  protected metaplex: Metaplex;
+
+  constructor(metaplex: Metaplex, options: RetryOptions) {
+    this.fn = options.function;
+    this.parameters = options.parameters;
+    this.numRetries = options.numRetries ?? 20;
+    this.timeout = options.timeout ?? 2000;
+    this.result = null;
+    this.metaplex = metaplex;
+  }
+
+  static make(metaplex: Metaplex, options: RetryOptions) {
+    return new RetryBuilder(metaplex, options);
+  }
+
+  async run(): Promise<any> {
+    for (let i=0;i<this.numRetries;i++) {
+      try {
+        this.result = await this.fn.apply(this, this.parameters);
+        break;
+      } catch (error) {
+        await new Promise(f => setTimeout(f, this.timeout));
+      }
+    }
+    return this;
+  }
+
+  getResult() {
+    return this.result;
+  }
+}
+

--- a/packages/js/src/utils/index.ts
+++ b/packages/js/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './GmaBuilder';
 export * from './GpaBuilder';
 export * from './log';
 export * from './merkle';
+export * from './RetryBuilder';
 export * from './Task';
 export * from './TransactionBuilder';
 export * from './types';


### PR DESCRIPTION
createNftBuilder.sendAndConfirm() takes some time to process before the new data is returned from findByMint (eventual consistency)

This issue is only apparent for some RPCs like Quicknode. The public RPC endpoints devnet and mainnet are not impacted.

Adding retries fixed the issue