### PR TITLE
Fix fee payer on update NFT operation

### DIFF
--- a/.changeset/strong-llamas-leave.md
+++ b/.changeset/strong-llamas-leave.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/js': patch
+---
+
+Fix fee payer on update NFT operation

--- a/packages/js/src/plugins/nftModule/operations/updateNft.ts
+++ b/packages/js/src/plugins/nftModule/operations/updateNft.ts
@@ -300,6 +300,7 @@ export const updateNftBuilder = (
 
   return (
     TransactionBuilder.make()
+      .setFeePayer(payer)
 
       // Unverify current collection before overriding it.
       // Otherwise, the previous collection size will not be properly decremented.


### PR DESCRIPTION
The `metaplex.nfts().update()` operation was not using the provided local fee payer in the returned transaction builder.