### PR TITLE
Add oldCollectionAuthority input to update NFT

### DIFF
--- a/.changeset/ten-cougars-end.md
+++ b/.changeset/ten-cougars-end.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/js': patch
+---
+
+Add oldCollectionAuthority input to update NFT operation

--- a/packages/js/src/plugins/nftModule/operations/updateNft.ts
+++ b/packages/js/src/plugins/nftModule/operations/updateNft.ts
@@ -186,7 +186,16 @@ export type UpdateNftInput = {
   collectionIsSized?: boolean;
 
   /**
-   * Whether or not the current asset's collection is a sized collection
+   * The authority of the asset's current collection.
+   * This may be required if the current collection is being removed
+   * or updated and needs to be unverified before doing so.
+   *
+   * @defaultValue `updateAuthority`
+   */
+  oldCollectionAuthority?: Signer;
+
+  /**
+   * Whether or not the asset's current collection is a sized collection
    * and not a legacy collection.
    *
    * @defaultValue `true`
@@ -313,7 +322,8 @@ export const updateNftBuilder = (
                 mintAddress: nftOrSft.address,
                 collectionMintAddress: nftOrSft.collection
                   ?.address as PublicKey,
-                collectionAuthority: updateAuthority,
+                collectionAuthority:
+                  params.oldCollectionAuthority ?? updateAuthority,
                 isSizedCollection: params.oldCollectionIsSized ?? true,
               },
               { programs, payer }


### PR DESCRIPTION
Offer the ability to explicitly provide the authority of the current collection NFT in case it is being unverified in order to be removed or updated.

See #431 