### PR TITLE
`replaceAssetsWithUris`: don't recurse into `MetaplexFile` objects

### DIFF
--- a/.changeset/eleven-cameras-melt.md
+++ b/.changeset/eleven-cameras-melt.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/js": patch
+---
+
+`replaceAssetsWithUris`: don't recurse into `MetaplexFile` objects

--- a/packages/js/src/plugins/nftModule/operations/uploadMetadata.ts
+++ b/packages/js/src/plugins/nftModule/operations/uploadMetadata.ts
@@ -116,11 +116,13 @@ export const replaceAssetsWithUris = (
   let index = 0;
 
   walk(clone, (next, value, key, parent) => {
-    if (isMetaplexFile(value) && index < replacements.length) {
-      parent[key] = replacements[index++];
+    if (isMetaplexFile(value)) {
+      if (index < replacements.length) {
+        parent[key] = replacements[index++];
+      }
+    } else {
+      next(value);
     }
-
-    next(value);
   });
 
   return clone as JsonMetadata;


### PR DESCRIPTION
While developing a MetaplexJS-based CLI tool with node.js that uploads very large assets, I observed a crash in `uploadMetadata`. After some debugging, I found that `replaceAssetsWithUris` will recurse into the `Buffer` object within a `MetaplexFile` instance, and if the `Buffer` is sufficiently large, `Object.keys` will fail and throw `RangeError`.

`getAssetsFromJsonMetadata` will only recurse into children of an object if it isn't a `MetaplexFile`; this change applies the same logic to `replaceAssetsWithUris`

Testing:
```
  const mx = await metaplex();
  const { uri, metadata } = await mx.nfts().uploadMetadata({
    name: 'JSON NFT name',
    description: 'JSON NFT description',
    image: toMetaplexFile(Buffer.alloc(500 * 1024 * 1024), 'some-file.bin'),
  });
```

Without this change:
```
    RangeError: Invalid array length
    -----------------------------------
      operator: error
      stack: |-
  RangeError: Invalid array length
  at Function.keys (<anonymous>)
  at walk (/Users/lavers/workspace/metaplex-js/packages/js/test/plugins/nftModule/packages/js/src/utils/common.ts:81:25)
  at recursiveWalk (/Users/lavers/workspace/metaplex-js/packages/js/test/plugins/nftModule/packages/js/src/utils/common.ts:74:41)
  at /Users/lavers/workspace/metaplex-js/packages/js/test/plugins/nftModule/packages/js/src/plugins/nftModule/operations/uploadMetadata.ts:125:7
  at /Users/lavers/workspace/metaplex-js/packages/js/test/plugins/nftModule/packages/js/src/utils/common.ts:89:7
  at Array.forEach (<anonymous>)
  at walk (/Users/lavers/workspace/metaplex-js/packages/js/test/plugins/nftModule/packages/js/src/utils/common.ts:87:10)
  at recursiveWalk (/Users/lavers/workspace/metaplex-js/packages/js/test/plugins/nftModule/packages/js/src/utils/common.ts:74:41)
  at /Users/lavers/workspace/metaplex-js/packages/js/test/plugins/nftModule/packages/js/src/plugins/nftModule/operations/uploadMetadata.ts:123:7
  at /Users/lavers/workspace/metaplex-js/packages/js/test/plugins/nftModule/packages/js/src/utils/common.ts:89:7
```

With this change: Operation succeeds (as expected)