### PR TITLE
Update Bundlr price logic

### DIFF
--- a/.changeset/good-gifts-explain.md
+++ b/.changeset/good-gifts-explain.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/js': patch
+---
+
+Update Bundlr price logic

--- a/packages/js/src/plugins/storageModule/StorageClient.ts
+++ b/packages/js/src/plugins/storageModule/StorageClient.ts
@@ -36,7 +36,11 @@ export class StorageClient implements HasDriver<StorageDriver> {
   }
 
   getUploadPriceForFiles(files: MetaplexFile[]): Promise<Amount> {
-    return this.getUploadPriceForBytes(getBytesFromMetaplexFiles(...files));
+    const driver = this.driver();
+
+    return driver.getUploadPriceForFiles
+      ? driver.getUploadPriceForFiles(files)
+      : this.getUploadPriceForBytes(getBytesFromMetaplexFiles(...files));
   }
 
   upload(file: MetaplexFile): Promise<string> {

--- a/packages/js/src/plugins/storageModule/StorageDriver.ts
+++ b/packages/js/src/plugins/storageModule/StorageDriver.ts
@@ -10,6 +10,7 @@ export type StorageDriver = {
     uri: string,
     options?: StorageDownloadOptions
   ) => Promise<MetaplexFile>;
+  getUploadPriceForFiles?: (files: MetaplexFile[]) => Promise<Amount>;
 };
 
 export type StorageDownloadOptions = Omit<RequestInit, 'signal'> & {


### PR DESCRIPTION
This PR takes into account the file header and the minimum size per file provided by Bundlr.

## Changelog
- Optionally enables storage drivers to override the `getUploadPriceForFiles` method since `getUploadPrice` does not give enough information.
- Implements `getUploadPriceForFiles` on the Bundlr storage driver which uses the new `HEADER_SIZE` and `MINIMUM_SIZE` variables before delegating to the `getUploadPrice` method.
- Updates the default price multiplier from `1.5` to `1.1` since the price computation is now accurate.