### PR TITLE
Ensure calling signTransaction uses the returned Transaction

### DIFF
--- a/.changeset/sixty-moons-eat.md
+++ b/.changeset/sixty-moons-eat.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/js': patch
+---
+
+Ensure calling signTransaction uses the returned Transaction

--- a/packages/js/src/plugins/rpcModule/RpcClient.ts
+++ b/packages/js/src/plugins/rpcModule/RpcClient.ts
@@ -95,7 +95,7 @@ export class RpcClient {
 
     // Identity signers.
     for (let i = 0; i < identities.length; i++) {
-      await identities[i].signTransaction(transaction);
+      transaction = await identities[i].signTransaction(transaction);
     }
 
     return transaction;


### PR DESCRIPTION
_This was initially [reported on Twitter](https://twitter.com/outofnowhereNFT/status/1603856571523547137?s=20&t=2-Ot_-PyCfzq6AzKgo1kTw). Thanks [@outofnowhereNFT](https://twitter.com/outofnowhereNFT) for raising this._

## Problem
The `RpcClient` class does not use the return value of the `signTransaction` method when signing transactions. This was okay until now as `signTransaction` implementations would also mutate the transaction provided as an argument before returning it. However, Phantom recently changed their implementation to return the signed transaction as a new object, leaving the initial one untouched.

## Solution
Use the returned transaction when calling the `signTransaction` method.