### PR TITLE
feat: Refactor auction house operations

### DIFF
--- a/packages/js/src/plugins/auctionHouseModule/AuctionHouseClient.ts
+++ b/packages/js/src/plugins/auctionHouseModule/AuctionHouseClient.ts
@@ -22,6 +22,8 @@ import {
   findAuctionHouseByAddressOperation,
   FindAuctionHouseByCreatorAndMintInput,
   findAuctionHouseByCreatorAndMintOperation,
+  FindAuctionHousesByAddressListInput,
+  findAuctionHousesByAddressListOperation,
   FindBidByReceiptInput,
   findBidByReceiptOperation,
   FindBidByTradeStateInput,
@@ -186,6 +188,16 @@ export class AuctionHouseClient {
     return this.metaplex
       .operations()
       .execute(findAuctionHouseByCreatorAndMintOperation(input), options);
+  }
+
+  /** {@inheritDoc findAuctionHousesByAddressListOperation} */
+  findByAddressList(
+    input: FindAuctionHousesByAddressListInput,
+    options?: OperationOptions
+  ) {
+    return this.metaplex
+      .operations()
+      .execute(findAuctionHousesByAddressListOperation(input), options);
   }
 
   /** {@inheritDoc findBidByReceiptOperation} */

--- a/packages/js/src/plugins/auctionHouseModule/operations/findAuctionHouseByAddress.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/findAuctionHouseByAddress.ts
@@ -1,6 +1,5 @@
 import type { PublicKey } from '@solana/web3.js';
 import { toAuctioneerAccount, toAuctionHouseAccount } from '../accounts';
-import { AuctioneerAuthorityRequiredError } from '../errors';
 import { AuctionHouse, toAuctionHouse } from '../models/AuctionHouse';
 import {
   Operation,
@@ -51,7 +50,7 @@ export type FindAuctionHouseByAddressInput = {
 
   /**
    * The Auctioneer authority key.
-   * It is required when Auction House has Auctioneer enabled.
+   * It is automatically loaded when not specified and Auction House has Auctioneer enabled.
    *
    * @defaultValue No default value.
    */
@@ -101,7 +100,9 @@ export const findAuctionHouseByAddressOperationHandler: OperationHandler<FindAuc
       }
 
       if (!accounts[1] || !accounts[1].exists) {
-        throw new AuctioneerAuthorityRequiredError();
+        accounts[1] = await metaplex
+          .rpc()
+          .getAccount(auctionHouseAccount.data.auctioneerAddress);
       }
 
       const auctioneerAccount = toAuctioneerAccount(accounts[1]);

--- a/packages/js/src/plugins/auctionHouseModule/operations/findAuctionHousesByAddressList.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/findAuctionHousesByAddressList.ts
@@ -1,0 +1,153 @@
+import { PublicKey } from '@solana/web3.js';
+import { toAuctioneerAccount, toAuctionHouseAccount } from '../accounts';
+import { AuctionHouse, toAuctionHouse } from '../models';
+import { toMint, toMintAccount } from '../../tokenModule';
+import { chunk } from '../../../utils/common';
+import {
+  Operation,
+  OperationHandler,
+  OperationScope,
+  UnparsedMaybeAccount,
+  useOperation,
+} from '@/types';
+import { Metaplex } from '@/Metaplex';
+
+// -----------------
+// Operation
+// -----------------
+
+const Key = 'FindAuctionHousesByAddressListOperation' as const;
+
+/**
+ * Finds multiple Auction Houses by their address.
+ *
+ * ```ts
+ * const nft = await metaplex
+ *   .auctionHouse()
+ *   .findByAddressList({ addresses };
+ * ```
+ *
+ * @group Operations
+ * @category Constructors
+ */
+export const findAuctionHousesByAddressListOperation =
+  useOperation<FindAuctionHousesByAddressListOperation>(Key);
+
+/**
+ * @group Operations
+ * @category Types
+ */
+export type FindAuctionHousesByAddressListOperation = Operation<
+  typeof Key,
+  FindAuctionHousesByAddressListInput,
+  FindAuctionHousesByAddressListOutput
+>;
+
+/**
+ * @group Operations
+ * @category Inputs
+ */
+export type FindAuctionHousesByAddressListInput = {
+  /** The addresses of the Auction Houses. */
+  addresses: PublicKey[];
+};
+
+/**
+ * @group Operations
+ * @category Outputs
+ */
+export type FindAuctionHousesByAddressListOutput = AuctionHouse[];
+
+const fetchUniqueAccountMap: <T = UnparsedMaybeAccount>(
+  metaplex: Metaplex,
+  accounts: PublicKey[],
+  mapper: (account: UnparsedMaybeAccount) => T,
+  accountMap?: Map<PublicKey, T>
+) => Promise<Map<PublicKey, T>> = async (
+  metaplex,
+  accounts,
+  mapper, // = (account) => account,
+  accountMap = new Map()
+) => {
+  const uniqueAccounts: Set<PublicKey> = new Set(
+    accounts.filter((key): key is PublicKey => key !== null)
+  );
+
+  const accountInfos = await Promise.all(
+    chunk(Array.from(uniqueAccounts), 100).map((chunk) =>
+      metaplex.rpc().getMultipleAccounts(chunk)
+    )
+  ).then((infos) => infos.flat());
+
+  for (const account of accountInfos) {
+    accountMap.set(account.publicKey, mapper(account));
+  }
+
+  return accountMap;
+};
+
+/**
+ * @group Operations
+ * @category Handlers
+ */
+export const findAuctionHousesByAddressListOperationHandler: OperationHandler<FindAuctionHousesByAddressListOperation> =
+  {
+    handle: async (
+      operation: FindAuctionHousesByAddressListOperation,
+      metaplex: Metaplex,
+      scope: OperationScope
+    ): Promise<FindAuctionHousesByAddressListOutput> => {
+      const { commitment } = scope;
+      const { addresses } = operation.input;
+
+      const auctionHouseUnparsedAccounts = await Promise.all(
+        chunk(addresses, 100).map((c) =>
+          metaplex.rpc().getMultipleAccounts(c, commitment)
+        )
+      );
+      scope.throwIfCanceled();
+
+      const auctionHouseAccounts = auctionHouseUnparsedAccounts
+        .flat()
+        .map((account) => toAuctionHouseAccount(account));
+
+      const mintAddresses = auctionHouseAccounts.map(
+        (auctionHouseAccount) => auctionHouseAccount.data.treasuryMint
+      );
+      const auctioneerAddresses = auctionHouseAccounts
+        .map(({ data: { hasAuctioneer, auctioneerAddress } }) =>
+          hasAuctioneer ? auctioneerAddress : null
+        )
+        .filter((key): key is PublicKey => key !== null);
+
+      const mintAndAuctioneerAccounts = await fetchUniqueAccountMap(
+        metaplex,
+        mintAddresses.concat(auctioneerAddresses),
+        (a) => a
+      );
+      scope.throwIfCanceled();
+
+      return auctionHouseAccounts.map((auctionHouseAccount) => {
+        const mintModel = toMint(
+          toMintAccount(
+            mintAndAuctioneerAccounts.get(
+              auctionHouseAccount.data.treasuryMint
+            )!
+          )
+        );
+
+        if (!auctionHouseAccount.data.hasAuctioneer)
+          return toAuctionHouse(auctionHouseAccount, mintModel);
+
+        return toAuctionHouse(
+          auctionHouseAccount,
+          mintModel,
+          toAuctioneerAccount(
+            mintAndAuctioneerAccounts.get(
+              auctionHouseAccount.data.auctioneerAddress
+            )!
+          )
+        );
+      });
+    },
+  };

--- a/packages/js/src/plugins/auctionHouseModule/operations/index.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/index.ts
@@ -9,6 +9,7 @@ export * from './directSell';
 export * from './executeSale';
 export * from './findAuctionHouseByAddress';
 export * from './findAuctionHouseByCreatorAndMint';
+export * from './findAuctionHousesByAddressList';
 export * from './findBidByReceipt';
 export * from './findBidByTradeState';
 export * from './findBids';

--- a/packages/js/src/plugins/auctionHouseModule/plugin.ts
+++ b/packages/js/src/plugins/auctionHouseModule/plugin.ts
@@ -24,6 +24,8 @@ import {
   findAuctionHouseByAddressOperationHandler,
   findAuctionHouseByCreatorAndMintOperation,
   findAuctionHouseByCreatorAndMintOperationHandler,
+  findAuctionHousesByAddressListOperation,
+  findAuctionHousesByAddressListOperationHandler,
   findBidByReceiptOperation,
   findBidByReceiptOperationHandler,
   findBidByTradeStateOperation,
@@ -103,6 +105,10 @@ export const auctionHouseModule = (): MetaplexPlugin => ({
     op.register(
       findAuctionHouseByCreatorAndMintOperation,
       findAuctionHouseByCreatorAndMintOperationHandler
+    );
+    op.register(
+      findAuctionHousesByAddressListOperation,
+      findAuctionHousesByAddressListOperationHandler
     );
     op.register(findBidByReceiptOperation, findBidByReceiptOperationHandler);
     op.register(

--- a/packages/js/test/plugins/auctionHouseModule/createAuctionHouse.test.ts
+++ b/packages/js/test/plugins/auctionHouseModule/createAuctionHouse.test.ts
@@ -176,6 +176,19 @@ test('[auctionHouseModule] create new Auctioneer Auction House', async (t: Test)
   // And the Auctioneer PDA for that Auction House was created.
   const ahAuctioneerAccount = await mx.rpc().getAccount(ahAuctioneerPda);
   t.ok(ahAuctioneerAccount.exists);
+
+  // Try fetching auctioneer auction house with only auctionHouse key
+  const retrievedAuctionHouse = await mx
+    .auctionHouse()
+    .findByAddress({ address: auctionHouse.address });
+  spok(t, retrievedAuctionHouse, {
+    hasAuctioneer: true,
+    scopes: AUCTIONEER_ALL_SCOPES,
+    auctioneer: {
+      address: spokSamePubkey(ahAuctioneerPda),
+      authority: spokSamePubkey(auctioneerAuthority.publicKey),
+    },
+  });
 });
 
 test('[auctionHouseModule] create new Auctioneer Auction House with separate authority', async (t: Test) => {


### PR DESCRIPTION
Refactor some auction house operations
- Automatically load `auctioneerAuthority` in `findAuctionHouseByAddress()`
- Add `findAuctionHousesByAddressList()` operation
- Make auctionHouse optional in `findListings()`