### PR TITLE
fix: Auction house doc examples

### DIFF
--- a/.changeset/long-crabs-tickle.md
+++ b/.changeset/long-crabs-tickle.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/js": patch
+---
+
+Update Auction house doc examples

--- a/packages/js/src/plugins/auctionHouseModule/AuctionHouseClient.ts
+++ b/packages/js/src/plugins/auctionHouseModule/AuctionHouseClient.ts
@@ -123,7 +123,7 @@ export class AuctionHouseClient {
       .execute(createBidOperation(input), options);
   }
 
-  /** {@inheritDoc buyOperation} */
+  /** {@inheritDoc directBuyOperation} */
   buy(input: DirectBuyInput, options?: OperationOptions) {
     return this.metaplex
       .operations()
@@ -299,7 +299,7 @@ export class AuctionHouseClient {
       .execute(loadPurchaseOperation(input), options);
   }
 
-  /** {@inheritDoc saleOperation} */
+  /** {@inheritDoc directSellOperation} */
   sell(input: DirectSellInput, options?: OperationOptions) {
     return this.metaplex
       .operations()

--- a/packages/js/src/plugins/auctionHouseModule/operations/createBid.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/createBid.ts
@@ -48,7 +48,7 @@ const Key = 'CreateBidOperation' as const;
  * ```ts
  * await metaplex
  *   .auctionHouse()
- *   .createBid({ auctionHouse, mintAccount, seller };
+ *   .bid({ auctionHouse, mintAccount, seller };
  * ```
  *
  * @group Operations

--- a/packages/js/src/plugins/auctionHouseModule/operations/createListing.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/createListing.ts
@@ -43,7 +43,7 @@ const Key = 'CreateListingOperation' as const;
  * ```ts
  * await metaplex
  *   .auctionHouse()
- *   .createListing({ auctionHouse, mintAccount };
+ *   .list({ auctionHouse, mintAccount };
  * ```
  *
  * @group Operations

--- a/packages/js/src/plugins/auctionHouseModule/operations/withdrawFromBuyerAccount.ts
+++ b/packages/js/src/plugins/auctionHouseModule/operations/withdrawFromBuyerAccount.ts
@@ -36,7 +36,7 @@ const Key = 'WithdrawFromBuyerAccountOperation' as const;
  * ```ts
  * await metaplex
  *   .auctionHouse()
- *   .withdraw({ auctionHouse, buyer, amount };
+ *   .withdrawFromBuyerAccount({ auctionHouse, buyer, amount };
  * ```
  *
  * @group Operations


### PR DESCRIPTION
Fix the examples in auction house module for the following methods:
-  `bid`
- `list`
- `withdrawFromBuyerAccount`

Fix the `@inheritDoc` in auction house module for the following operations:
- `directBuyOperation`
- `directSellOperation` 