### PR TITLE
[WIP] Add support for compressed NFTs

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -45,12 +45,14 @@
     "@bundlr-network/client": "^0.8.8",
     "@metaplex-foundation/beet": "0.7.1",
     "@metaplex-foundation/mpl-auction-house": "^2.3.0",
+    "@metaplex-foundation/mpl-bubblegum": "^0.6.2",
     "@metaplex-foundation/mpl-candy-guard": "^0.3.0",
     "@metaplex-foundation/mpl-candy-machine": "^5.0.0",
     "@metaplex-foundation/mpl-candy-machine-core": "^0.1.2",
     "@metaplex-foundation/mpl-token-metadata": "^2.7.0",
     "@noble/ed25519": "^1.7.1",
     "@noble/hashes": "^1.1.3",
+    "@solana/spl-account-compression": "^0.1.5",
     "@solana/spl-token": "^0.3.5",
     "@solana/web3.js": "^1.63.1",
     "bignumber.js": "^9.0.2",
@@ -63,7 +65,8 @@
     "lodash.isequal": "^4.5.0",
     "merkletreejs": "^0.2.32",
     "mime": "^3.0.0",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.7",
+    "typescript-collections": "^1.3.3"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts",

--- a/packages/js/src/Metaplex.ts
+++ b/packages/js/src/Metaplex.ts
@@ -1,6 +1,7 @@
 import { Connection } from '@solana/web3.js';
 import { MetaplexPlugin, Cluster, resolveClusterFromConnection } from '@/types';
 import { corePlugins } from '@/plugins/corePlugins';
+import { ReadApiConnection } from './utils/readApiConnection';
 
 export type MetaplexOptions = {
   cluster?: Cluster;
@@ -8,7 +9,7 @@ export type MetaplexOptions = {
 
 export class Metaplex {
   /** The connection object from Solana's SDK. */
-  public readonly connection: Connection;
+  public readonly connection: Connection | ReadApiConnection;
 
   /** The cluster in which the connection endpoint belongs to. */
   public readonly cluster: Cluster;

--- a/packages/js/src/plugins/nftModule/NftClient.ts
+++ b/packages/js/src/plugins/nftModule/NftClient.ts
@@ -70,6 +70,10 @@ import {
   VerifyNftCreatorInput,
   verifyNftCreatorOperation,
 } from './operations';
+import {
+  FindNftByAssetIdInput,
+  findNftByAssetIdOperation,
+} from './operations/findNftByAssetId';
 import { OperationOptions } from '@/types';
 import type { Metaplex } from '@/Metaplex';
 
@@ -193,6 +197,14 @@ export class NftClient {
     return this.metaplex
       .operations()
       .execute(findNftsByUpdateAuthorityOperation(input), options);
+  }
+
+  // TODO(jon): Fix this doc
+  /** {@inheritDoc findNftByMintOperation} */
+  findByAssetId(input: FindNftByAssetIdInput, options?: OperationOptions) {
+    return this.metaplex
+      .operations()
+      .execute(findNftByAssetIdOperation(input), options);
   }
 
   /** {@inheritDoc loadMetadataOperation} */

--- a/packages/js/src/plugins/nftModule/models/Nft.ts
+++ b/packages/js/src/plugins/nftModule/models/Nft.ts
@@ -6,6 +6,17 @@ import { isSftWithToken, SftWithToken, toSft, toSftWithToken } from './Sft';
 import { assert } from '@/utils';
 import type { Pda } from '@/types';
 
+// Not a model since this is over-the-wire information, not on-chain properties
+type CompressionMetadata = {
+  compressed: boolean;
+  data_hash: string;
+  creator_hash: string;
+  asset_hash: string;
+  tree: string;
+  seq: number;
+  leaf_id: number;
+};
+
 /**
  * This model captures all the relevant information about an NFT
  * in the Solana blockchain. That includes the NFT's metadata account,
@@ -31,6 +42,8 @@ export type Nft = Omit<Metadata, 'model' | 'address' | 'mintAddress'> & {
    * printed edition and provides additional information accordingly.
    */
   readonly edition: NftEdition;
+} & {
+  compression?: CompressionMetadata;
 };
 
 /** @group Model Helpers */

--- a/packages/js/src/plugins/nftModule/operations/createCompressedNft.ts
+++ b/packages/js/src/plugins/nftModule/operations/createCompressedNft.ts
@@ -1,0 +1,470 @@
+import { TokenStandard, Uses } from '@metaplex-foundation/mpl-token-metadata';
+import {
+  TokenProgramVersion,
+  createMintToCollectionV1Instruction,
+  PROGRAM_ID as BUBBLEGUM_PROGRAM_ID,
+} from '@metaplex-foundation/mpl-bubblegum';
+import {
+  SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+  // getConcurrentMerkleTreeAccountSize,
+  SPL_NOOP_PROGRAM_ID,
+  // ConcurrentMerkleTreeAccount,
+} from '@solana/spl-account-compression';
+import { PROGRAM_ID as TOKEN_METADATA_PROGRAM_ID } from '@metaplex-foundation/mpl-token-metadata';
+import { PublicKey } from '@solana/web3.js';
+import { SendAndConfirmTransactionResponse } from '../../rpcModule';
+import { assertNft, Nft } from '../models';
+import { Option, TransactionBuilder, TransactionBuilderOptions } from '@/utils';
+import {
+  Creator,
+  CreatorInput,
+  makeConfirmOptionsFinalizedOnMainnet,
+  Operation,
+  OperationHandler,
+  OperationScope,
+  Signer,
+  useOperation,
+} from '@/types';
+import { Metaplex } from '@/Metaplex';
+
+// -----------------
+// Operation
+// -----------------
+
+const Key = 'CreateCompressedNftOperation' as const;
+
+/**
+ * Creates a new compressed NFT.
+ *
+ * ```ts
+ * const { nft } = await metaplex
+ *   .nfts()
+ *   .createNft({
+ *     name: 'My SFT',
+ *     uri: 'https://example.com/my-nft',
+ *     sellerFeeBasisPoints: 250, // 2.5%
+ *     tree: merkleTreeAccount
+ *   };
+ * ```
+ *
+ * @group Operations
+ * @category Constructors
+ */
+export const createCompressedNftOperation =
+  useOperation<CreateCompressedNftOperation>(Key);
+
+/**
+ * @group Operations
+ * @category Types
+ */
+export type CreateCompressedNftOperation = Operation<
+  typeof Key,
+  CreateCompressedNftInput,
+  CreateCompressedNftOutput
+>;
+
+/**
+ * @group Operations
+ * @category Inputs
+ */
+export type CreateCompressedNftInput = {
+  /**
+   * The authority that will be able to make changes
+   * to the created SFT.
+   *
+   * This is required as a Signer because creating the
+   * metadata account requires the update authority to be part
+   * of the creators array as a verified creator.
+   *
+   * @defaultValue `metaplex.identity()`
+   */
+  updateAuthority?: Signer;
+
+  /**
+   * The address corresponding to the merkle tree where this
+   * compressed NFT will be stored.
+   *
+   * Must be created ahead of time.
+   *
+   * @defaultValue `metaplex.identity()`
+   */
+  tree: PublicKey;
+
+  /**
+   * The owner of a token account associated with the SFT to create.
+   *
+   * This is completely optional as creating an SFT does not require
+   * the existence of a token account. When provided, an associated
+   * token account will be created from the given owner.
+   *
+   * You may alternatively pass the `tokenAddress` parameter instead.
+   *
+   * @defaultValue Defaults to not creating and/or minting
+   * any token account.
+   */
+  tokenOwner?: PublicKey;
+
+  /** The URI that points to the JSON metadata of the asset. */
+  uri: string;
+
+  /** The on-chain name of the asset, e.g. "My SFT". */
+  name: string;
+
+  /**
+   * The royalties in percent basis point (i.e. 250 is 2.5%) that
+   * should be paid to the creators on each secondary sale.
+   */
+  sellerFeeBasisPoints: number;
+
+  /**
+   * The on-chain symbol of the asset, stored in the Metadata account.
+   * E.g. "MYSFT".
+   *
+   * @defaultValue `""`
+   */
+  symbol?: string;
+
+  /**
+   * {@inheritDoc CreatorInput}
+   * @defaultValue
+   * Defaults to using the provided `updateAuthority` as the only verified creator.
+   * ```ts
+   * [{
+   *   address: updateAuthority.publicKey,
+   *   authority: updateAuthority,
+   *   share: 100,
+   * }]
+   * ```
+   */
+  creators?: CreatorInput[];
+
+  /**
+   * Whether or not the SFT's metadata is mutable.
+   * When set to `false` no one can update the Metadata account,
+   * not even the update authority.
+   *
+   * @defaultValue `true`
+   */
+  isMutable?: boolean;
+
+  /**
+   * When this field is not `null`, it indicates that the SFT
+   * can be "used" by its owner or any approved "use authorities".
+   *
+   * @defaultValue `null`
+   */
+  uses?: Option<Uses>;
+
+  /**
+   * The Collection NFT that this new SFT belongs to.
+   * When `null`, the created SFT will not be part of a collection.
+   *
+   * @defaultValue `null`
+   */
+  collection?: Option<PublicKey>;
+
+  /**
+   * The collection authority that should sign the created SFT
+   * to prove that it is part of the provided collection.
+   * When `null`, the provided `collection` will not be verified.
+   *
+   * @defaultValue `null`
+   */
+  collectionAuthority?: Option<Signer>;
+
+  /**
+   * Whether or not the provided `collectionAuthority` is a delegated
+   * collection authority, i.e. it was approved by the update authority
+   * using `metaplex.nfts().approveCollectionAuthority()`.
+   *
+   * @defaultValue `false`
+   */
+  collectionAuthorityIsDelegated?: boolean;
+
+  /**
+   * Whether or not the provided `collection` is a sized collection
+   * and not a legacy collection.
+   *
+   * @defaultValue `true`
+   */
+  collectionIsSized?: boolean;
+};
+
+/**
+ * @group Operations
+ * @category Outputs
+ */
+export type CreateCompressedNftOutput = {
+  /** The blockchain response from sending and confirming the transaction. */
+  response: SendAndConfirmTransactionResponse;
+
+  /** The newly created SFT and, potentially, its associated token. */
+  nft: Nft;
+
+  /** The asset id of the leaf. */
+  mintAddress: PublicKey;
+};
+
+/**
+ * @group Operations
+ * @category Handlers
+ */
+export const createCompressedNftOperationHandler: OperationHandler<CreateCompressedNftOperation> =
+  {
+    handle: async (
+      operation: CreateCompressedNftOperation,
+      metaplex: Metaplex,
+      scope: OperationScope
+    ) => {
+      const builder = await createCompressedNftBuilder(
+        metaplex,
+        operation.input,
+        scope
+      );
+      scope.throwIfCanceled();
+
+      const confirmOptions = makeConfirmOptionsFinalizedOnMainnet(
+        metaplex,
+        scope.confirmOptions
+      );
+      const output = await builder.sendAndConfirm(metaplex, confirmOptions);
+      scope.throwIfCanceled();
+
+      // TODO(jon): Expand this
+      const nft = await metaplex.nfts().findByMint(
+        {
+          mintAddress: output.mintAddress,
+        },
+        scope
+      );
+      scope.throwIfCanceled();
+
+      assertNft(nft);
+      return { ...output, nft };
+    },
+  };
+
+// -----------------
+// Builder
+// -----------------
+
+/**
+ * @group Transaction Builders
+ * @category Inputs
+ */
+export type CreateCompressedNftBuilderParams = Omit<
+  CreateCompressedNftInput,
+  'confirmOptions' | 'tokenAddress' | 'metadataAddress' | 'masterEditionAddress'
+> & {
+  /**
+   * Whether or not the provided token account already exists.
+   * If `false`, we'll add another instruction to create it.
+   *
+   * @defaultValue `true`
+   */
+  tokenExists?: boolean;
+
+  /** A key to distinguish the instruction that creates the mint account. */
+  createMintAccountInstructionKey?: string;
+
+  /** A key to distinguish the instruction that initializes the mint account. */
+  initializeMintInstructionKey?: string;
+
+  /** A key to distinguish the instruction that creates the associated token account. */
+  createAssociatedTokenAccountInstructionKey?: string;
+
+  /** A key to distinguish the instruction that creates the token account. */
+  createTokenAccountInstructionKey?: string;
+
+  /** A key to distinguish the instruction that initializes the token account. */
+  initializeTokenInstructionKey?: string;
+
+  /** A key to distinguish the instruction that mints tokens. */
+  mintTokensInstructionKey?: string;
+
+  /** A key to distinguish the instruction that creates the metadata account. */
+  createMetadataInstructionKey?: string;
+};
+
+/**
+ * @group Transaction Builders
+ * @category Contexts
+ */
+export type CreateCompressedNftBuilderContext = Omit<
+  CreateCompressedNftOutput,
+  'response' | 'nft'
+>;
+
+/**
+ * Creates a new SFT.
+ *
+ * ```ts
+ * const transactionBuilder = await metaplex
+ *   .nfts()
+ *   .builders()
+ *   .createCompressedNft({
+ *     name: 'My SFT',
+ *     uri: 'https://example.com/my-nft',
+ *     sellerFeeBasisPoints: 250, // 2.5%
+ *     tree: merkleTreeAccount
+ *   });
+ * ```
+ *
+ * @group Transaction Builders
+ * @category Constructors
+ */
+export const createCompressedNftBuilder = async (
+  metaplex: Metaplex,
+  params: CreateCompressedNftBuilderParams,
+  options: TransactionBuilderOptions = {}
+): Promise<TransactionBuilder<CreateCompressedNftBuilderContext>> => {
+  const { payer = metaplex.rpc().getDefaultFeePayer() } = options;
+  const { updateAuthority = metaplex.identity(), tree } = params;
+
+  const creatorsInput: CreatorInput[] = params.creators ?? [
+    {
+      address: updateAuthority.publicKey,
+      authority: updateAuthority,
+      share: 100,
+    },
+  ];
+  const creators: Option<Creator[]> =
+    creatorsInput.length > 0
+      ? creatorsInput.map((creator) => ({
+          ...creator,
+          verified: creator.address.equals(updateAuthority.publicKey),
+        }))
+      : null;
+
+  // Likely that this information can only be derived after the mint
+  // const verifyAdditionalCreatorInstructions = creatorsInput
+  //   .filter((creator) => {
+  //     return (
+  //       !!creator.authority &&
+  //       !creator.address.equals(updateAuthority.publicKey)
+  //     );
+  //   })
+  //   .map((creator) => {
+  //     return metaplex.nfts().builders().verifyCreator(
+  //       {
+  //         mintAddress,
+  //         creator: creator.authority,
+  //       },
+  //       { programs, payer }
+  //     );
+  //   });
+
+  return (
+    TransactionBuilder.make<CreateCompressedNftBuilderContext>()
+      .setFeePayer(payer)
+
+      // .setContext({
+      //   mintAddress,
+      //   metadataAddress: metadataPda,
+      //   tokenAddress,
+      // })
+
+      // Verify additional creators.
+      // TODO(jon): Add the creator verification instructions
+      // .add(...verifyAdditionalCreatorInstructions)
+
+      // Verify collection.
+      .when(!!params.collection && !!params.collectionAuthority, (builder) => {
+        const { collection, collectionAuthority } = params;
+
+        const [collectionMetadataAddress] = PublicKey.findProgramAddressSync(
+          [
+            Buffer.from('metadata', 'utf8'),
+            TOKEN_METADATA_PROGRAM_ID.toBuffer(),
+            (collection as PublicKey).toBuffer(),
+          ],
+          TOKEN_METADATA_PROGRAM_ID
+        );
+
+        const [collectionMasterEditionAccount] =
+          PublicKey.findProgramAddressSync(
+            [
+              Buffer.from('metadata', 'utf8'),
+              TOKEN_METADATA_PROGRAM_ID.toBuffer(),
+              (collection as PublicKey).toBuffer(),
+              Buffer.from('edition', 'utf8'),
+            ],
+            TOKEN_METADATA_PROGRAM_ID
+          );
+
+        const [treeAuthority] = PublicKey.findProgramAddressSync(
+          [tree.toBuffer()],
+          BUBBLEGUM_PROGRAM_ID
+        );
+
+        const [bubblegumPDA] = PublicKey.findProgramAddressSync(
+          [Buffer.from('collection_cpi', 'utf8')],
+          BUBBLEGUM_PROGRAM_ID
+        );
+
+        return builder.add({
+          instruction:
+            // TODO(jon): We should be able to infer some of these in an intermediary SDK
+            createMintToCollectionV1Instruction(
+              {
+                payer: payer.publicKey,
+
+                merkleTree: tree,
+                treeAuthority,
+                // TODO(jon): Replace this delegate
+                treeDelegate: payer.publicKey,
+
+                // TODO(jon): This should respect the configured owner
+                leafOwner: payer.publicKey,
+                leafDelegate: payer.publicKey,
+
+                collectionMetadata: collectionMetadataAddress,
+                collectionMint: collection as PublicKey,
+                collectionAuthority: (collectionAuthority as Signer).publicKey,
+                // TODO(jon): This should be `collectionMasterEditionAccount`
+                editionAccount: collectionMasterEditionAccount,
+
+                // TODO(jon): Pass along another parameter for this field and default to the BUBBLEGUM_PROGRAM_ID
+                collectionAuthorityRecordPda: BUBBLEGUM_PROGRAM_ID,
+
+                bubblegumSigner: bubblegumPDA,
+
+                // Programs
+                /* Account Compression */
+                compressionProgram: SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+                // TODO(jon): This argument should be `logWrapperProgram`
+                logWrapper: SPL_NOOP_PROGRAM_ID,
+
+                /* Bubblegum */
+                tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
+              },
+              {
+                metadataArgs: {
+                  ...params,
+
+                  symbol: params.symbol ?? '',
+                  creators: creators ?? [],
+
+                  isMutable: !!params.isMutable,
+                  uses: params.uses ?? null,
+
+                  // Only NonFungible tokens are supported.
+                  tokenStandard: TokenStandard.NonFungible,
+                  collection: {
+                    key: collection as PublicKey,
+                    // TODO(jon): Can we verify this here or do we need to send a separate instruction?
+                    verified: false,
+                  },
+
+                  primarySaleHappened: false,
+                  editionNonce: null,
+
+                  tokenProgramVersion: TokenProgramVersion.Original,
+                },
+              }
+            ),
+          signers: [payer, params.collectionAuthority as Signer],
+        });
+      })
+  );
+};

--- a/packages/js/src/plugins/nftModule/operations/createNft.ts
+++ b/packages/js/src/plugins/nftModule/operations/createNft.ts
@@ -2,6 +2,10 @@ import { TokenStandard, Uses } from '@metaplex-foundation/mpl-token-metadata';
 import { Keypair, PublicKey } from '@solana/web3.js';
 import { SendAndConfirmTransactionResponse } from '../../rpcModule';
 import { assertNftWithToken, NftWithToken } from '../models';
+import {
+  createCompressedNftBuilder,
+  CreateCompressedNftBuilderParams,
+} from './createCompressedNft';
 import { Option, TransactionBuilder, TransactionBuilderOptions } from '@/utils';
 import {
   BigNumber,
@@ -260,6 +264,11 @@ export type CreateNftInput = {
    * @defaultValue `null`
    */
   ruleSet?: Option<PublicKey>;
+
+  /**
+   * The Merkle tree used to store the NFT
+   */
+  tree?: Option<PublicKey>;
 };
 
 /**
@@ -424,7 +433,17 @@ export const createNftBuilder = async (
     mintAuthority = metaplex.identity(),
     tokenOwner = metaplex.identity().publicKey,
     mintTokens = true,
+    tree,
   } = params;
+
+  if (tree) {
+    // @ts-ignore
+    return createCompressedNftBuilder(
+      metaplex,
+      params as CreateCompressedNftBuilderParams,
+      options
+    );
+  }
 
   const sftBuilder = await metaplex
     .nfts()

--- a/packages/js/src/plugins/nftModule/operations/findNftByAssetId.ts
+++ b/packages/js/src/plugins/nftModule/operations/findNftByAssetId.ts
@@ -1,0 +1,90 @@
+import { PublicKey } from '@solana/web3.js';
+import { Nft, toNft } from '../models';
+import {
+  Operation,
+  OperationHandler,
+  OperationScope,
+  useOperation,
+} from '@/types';
+import { Metaplex } from '@/Metaplex';
+import {
+  GetAssetRpcResponse,
+  toMetadataFromReadApiAsset,
+  toMintFromReadApiAsset,
+  toNftEditionFromReadApiAsset,
+} from '@/utils/readApiConnection';
+
+// -----------------
+// Operation
+// -----------------
+
+const Key = 'FindNftByAssetIdOperation' as const;
+
+/**
+ * Finds an NFT or an SFT by its mint address.
+ *
+ * ```ts
+ * const nft = await metaplex
+ *   .nfts()
+ *   .findByAssetId({ assetId };
+ * ```
+ *
+ * @group Operations
+ * @category Constructors
+ */
+export const findNftByAssetIdOperation =
+  useOperation<FindNftByAssetIdOperation>(Key);
+
+/**
+ * @group Operations
+ * @category Types
+ */
+export type FindNftByAssetIdOperation = Operation<
+  typeof Key,
+  FindNftByAssetIdInput,
+  FindNftByAssetIdOutput
+>;
+
+/**
+ * @group Operations
+ * @category Inputs
+ */
+export type FindNftByAssetIdInput = {
+  /** The id of an asset. */
+  assetId: PublicKey;
+};
+
+/**
+ * @group Operations
+ * @category Outputs
+ */
+export type FindNftByAssetIdOutput = Nft;
+
+/**
+ * @group Operations
+ * @category Handlers
+ */
+export const findNftByAssetIdOperationHandler: OperationHandler<FindNftByAssetIdOperation> =
+  {
+    handle: async (
+      operation: FindNftByAssetIdOperation,
+      metaplex: Metaplex,
+      scope: OperationScope
+    ): Promise<FindNftByAssetIdOutput> => {
+      const { assetId } = operation.input;
+
+      // Retrieve asset from RPC
+      // Massage into the NFT model
+
+      const asset = await metaplex.rpc().getAsset(assetId);
+      scope.throwIfCanceled();
+
+      const metadata = toMetadataFromReadApiAsset(asset as GetAssetRpcResponse);
+      const mint = toMintFromReadApiAsset(asset as GetAssetRpcResponse);
+      const nftEdition = toNftEditionFromReadApiAsset(
+        asset as GetAssetRpcResponse
+      );
+
+      return toNft(metadata, mint, nftEdition);
+    },
+  };

--- a/packages/js/src/plugins/nftModule/operations/index.ts
+++ b/packages/js/src/plugins/nftModule/operations/index.ts
@@ -4,6 +4,7 @@ export * from './approveNftUseAuthority';
 export * from './createNft';
 export * from './createSft';
 export * from './deleteNft';
+export * from './findNftByAssetId';
 export * from './findNftByMetadata';
 export * from './findNftByMint';
 export * from './findNftByToken';

--- a/packages/js/src/plugins/nftModule/plugin.ts
+++ b/packages/js/src/plugins/nftModule/plugin.ts
@@ -14,6 +14,8 @@ import {
   createSftOperationHandler,
   deleteNftOperation,
   deleteNftOperationHandler,
+  findNftByAssetIdOperation,
+  findNftByAssetIdOperationHandler,
   findNftByMetadataOperation,
   findNftByMetadataOperationHandler,
   findNftByMintOperation,
@@ -105,6 +107,7 @@ export const nftModule = (): MetaplexPlugin => ({
     op.register(createNftOperation, createNftOperationHandler);
     op.register(createSftOperation, createSftOperationHandler);
     op.register(deleteNftOperation, deleteNftOperationHandler);
+    op.register(findNftByAssetIdOperation, findNftByAssetIdOperationHandler);
     op.register(findNftByMetadataOperation, findNftByMetadataOperationHandler);
     op.register(findNftByMintOperation, findNftByMintOperationHandler);
     op.register(findNftByTokenOperation, findNftByTokenOperationHandler);

--- a/packages/js/src/plugins/rpcModule/RpcClient.ts
+++ b/packages/js/src/plugins/rpcModule/RpcClient.ts
@@ -20,6 +20,7 @@ import {
   FailedToSendTransactionError,
   MetaplexError,
   ParsedProgramError,
+  RpcError,
   UnknownProgramError,
 } from '@/errors';
 import type { Metaplex } from '@/Metaplex';
@@ -35,6 +36,11 @@ import {
   UnparsedMaybeAccount,
 } from '@/types';
 import { TransactionBuilder, zipMap } from '@/utils';
+import {
+  GetAssetProofRpcResponse,
+  GetAssetRpcResponse,
+  ReadApiConnection,
+} from '@/utils/readApiConnection';
 
 export type ConfirmTransactionResponse = RpcResponseAndContext<SignatureResult>;
 export type SendAndConfirmTransactionResponse = {
@@ -316,6 +322,30 @@ export class RpcClient {
       exists: true,
       lamports: lamports(accountInfo.lamports),
     };
+  }
+
+  async getAsset(
+    assetId: PublicKey
+  ): Promise<GetAssetRpcResponse | MetaplexError> {
+    if (this.metaplex.connection instanceof ReadApiConnection) {
+      return await this.metaplex.connection.getAsset(assetId);
+    }
+
+    return new RpcError(
+      'Method not supported! Use a ReadApiConnection instead'
+    );
+  }
+
+  async getAssetProof(
+    assetId: PublicKey
+  ): Promise<GetAssetProofRpcResponse | MetaplexError> {
+    if (this.metaplex.connection instanceof ReadApiConnection) {
+      return await this.metaplex.connection.getAssetProof(assetId);
+    }
+
+    return new RpcError(
+      'Method not supported! Use a ReadApiConnection instead'
+    );
   }
 
   protected parseProgramError(

--- a/packages/js/src/types/BigNumber.ts
+++ b/packages/js/src/types/BigNumber.ts
@@ -1,6 +1,7 @@
 import type { Buffer } from 'buffer';
 import BN from 'bn.js';
-import { assert, Opaque, Option } from '@/utils';
+import { default as assert } from '@/utils/assert';
+import type { Opaque, Option } from '@/utils';
 
 export type BigNumber = Opaque<BN, 'BigNumber'>;
 export type BigNumberValues =

--- a/packages/js/src/types/DateTime.ts
+++ b/packages/js/src/types/DateTime.ts
@@ -1,6 +1,7 @@
 import BN from 'bn.js';
 import { BigNumberValues } from './BigNumber';
-import { assert, Opaque, Option } from '@/utils';
+import { default as assert } from '@/utils/assert';
+import type { Opaque, Option } from '@/utils';
 
 export type DateTimeString = string;
 export type DateTimeValues = DateTimeString | BigNumberValues | Date;

--- a/packages/js/src/types/Model.ts
+++ b/packages/js/src/types/Model.ts
@@ -1,4 +1,4 @@
-import { assert } from '../utils';
+import { default as assert } from '@/utils/assert';
 
 /**
  * A helper type that defines a model as an opaque type.

--- a/packages/js/src/utils/index.ts
+++ b/packages/js/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './GmaBuilder';
 export * from './GpaBuilder';
 export * from './log';
 export * from './merkle';
+export * from './readApiConnection';
 export * from './Task';
 export * from './TransactionBuilder';
 export * from './types';

--- a/packages/js/src/utils/readApiConnection.ts
+++ b/packages/js/src/utils/readApiConnection.ts
@@ -10,8 +10,9 @@ import {
   PublicKey,
 } from '@solana/web3.js';
 import BN from 'bn.js';
-import type { Metadata, Mint, NftOriginalEdition } from '..';
-import { amount, Pda, SplTokenCurrency, toBigNumber } from '@/types';
+import type { Metadata, Mint, NftOriginalEdition } from '@/plugins';
+import type { SplTokenCurrency } from '@/types';
+import { Pda, amount, toBigNumber } from '@/types';
 
 type JsonRpcParams<ReadApiMethodParams> = {
   method: string;
@@ -101,7 +102,9 @@ export const toMintFromReadApiAsset = (input: GetAssetRpcResponse): Mint => {
 export const toMetadataFromReadApiAsset = (
   input: GetAssetRpcResponse
 ): Metadata => {
-  const updateAuthority = input.authorities.find((authority) =>
+  console.info({ input });
+
+  const updateAuthority = input.authorities?.find((authority) =>
     authority.scopes.includes('full')
   );
 
@@ -158,13 +161,15 @@ export class ReadApiConnection extends Connection {
   private callReadApi = async <ReadApiMethodParams, ReadApiJsonOutput>(
     jsonRpcParams: JsonRpcParams<ReadApiMethodParams>
   ): Promise<JsonRpcOutput<ReadApiJsonOutput>> => {
-    // Array-ify the params
     const response = await fetch(this.rpcEndpoint, {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({
         jsonrpc: '2.0',
         method: jsonRpcParams.method,
-        id: jsonRpcParams.id,
+        id: jsonRpcParams.id ?? 'rpd-op-123',
         params: jsonRpcParams.params,
       }),
     });
@@ -179,7 +184,7 @@ export class ReadApiConnection extends Connection {
       GetAssetRpcInput,
       GetAssetRpcResponse
     >({
-      method: 'get_asset',
+      method: 'getAsset',
       params: {
         id: assetId.toBase58(),
       },
@@ -196,7 +201,7 @@ export class ReadApiConnection extends Connection {
       GetAssetProofRpcInput,
       GetAssetProofRpcResponse
     >({
-      method: 'get_asset_proof',
+      method: 'getAssetProof',
       params: {
         id: assetId.toBase58(),
       },

--- a/packages/js/src/utils/readApiConnection.ts
+++ b/packages/js/src/utils/readApiConnection.ts
@@ -1,0 +1,209 @@
+// TODO(jon): Pretty sure this whole file should just be a separate package that gets packaged
+// alongside the Read API instead
+
+import { TokenStandard } from '@metaplex-foundation/mpl-token-metadata';
+import { PROGRAM_ID as BUBBLEGUM_PROGRAM_ID } from '@metaplex-foundation/mpl-bubblegum';
+import {
+  Commitment,
+  Connection,
+  ConnectionConfig,
+  PublicKey,
+} from '@solana/web3.js';
+import BN from 'bn.js';
+import type { Metadata, Mint, NftOriginalEdition } from '..';
+import { amount, Pda, SplTokenCurrency, toBigNumber } from '@/types';
+
+type JsonRpcParams<ReadApiMethodParams> = {
+  method: string;
+  id?: string;
+  params: ReadApiMethodParams;
+};
+
+type JsonRpcOutput<ReadApiJsonOutput> = {
+  result: ReadApiJsonOutput;
+};
+
+export type GetAssetRpcInput = {
+  id: string;
+};
+
+export type GetAssetRpcResponse = {
+  id: string;
+  interface: 'V1_NFT';
+  content: {
+    json_uri: string;
+    metadata: Metadata['json'];
+  };
+  authorities: Array<{ address: string; scopes: ['full'] }>;
+  mutable: boolean;
+  royalty: {
+    primary_sale_happened: boolean;
+    basis_points: number;
+  };
+  supply: {
+    edition_nonce: number;
+    print_current_supply: number;
+    print_max_supply: number;
+  };
+  creators: Metadata['creators'];
+  grouping: Array<{ group_key: 'collection'; group_value: string }>;
+  compression: {
+    tree: string;
+    leaf_id: number;
+  };
+};
+
+type GetAssetProofRpcInput = {
+  id: string;
+};
+
+export type GetAssetProofRpcResponse = {
+  root: string;
+  proof: string[];
+  node_index: number;
+  leaf: string;
+  tree_id: string;
+};
+
+export const toNftEditionFromReadApiAsset = (
+  input: GetAssetRpcResponse
+): NftOriginalEdition => {
+  return {
+    model: 'nftEdition',
+    isOriginal: true,
+    address: new PublicKey(input.id),
+    supply: toBigNumber(input.supply.print_current_supply),
+    maxSupply: toBigNumber(input.supply.print_max_supply),
+  };
+};
+
+export const toMintFromReadApiAsset = (input: GetAssetRpcResponse): Mint => {
+  const currency: SplTokenCurrency = {
+    symbol: 'Token',
+    decimals: 0,
+    namespace: 'spl-token',
+  };
+
+  return {
+    model: 'mint',
+    address: new PublicKey(input.id),
+    // TODO(jon): Presumably, this should be the Master Edition address upon decompression
+    mintAuthorityAddress: new PublicKey(input.id),
+    // TODO(jon): Presumably, this should be the Master Edition address upon decompression
+    freezeAuthorityAddress: new PublicKey(input.id),
+    decimals: 0,
+    supply: amount(1, currency),
+    isWrappedSol: false,
+    currency,
+  };
+};
+
+export const toMetadataFromReadApiAsset = (
+  input: GetAssetRpcResponse
+): Metadata => {
+  const updateAuthority = input.authorities.find((authority) =>
+    authority.scopes.includes('full')
+  );
+
+  const collection = input.grouping.find(
+    ({ group_key }) => group_key === 'collection'
+  );
+
+  return {
+    model: 'metadata',
+    // TODO(jon): We technically don't have a metadata address anymore. We can derive one though
+    address: Pda.find(BUBBLEGUM_PROGRAM_ID, [
+      Buffer.from('asset', 'utf-8'),
+      new PublicKey(input.compression.tree).toBuffer(),
+      Uint8Array.from(new BN(input.compression.leaf_id).toArray('le', 8)),
+    ]),
+    mintAddress: new PublicKey(input.id),
+    updateAuthorityAddress: new PublicKey(updateAuthority!.address),
+
+    name: input.content.metadata?.name ?? '',
+    symbol: input.content.metadata?.symbol ?? '',
+
+    json: input.content.metadata,
+    jsonLoaded: true,
+    uri: input.content.json_uri,
+    isMutable: input.mutable,
+
+    primarySaleHappened: input.royalty.primary_sale_happened,
+    sellerFeeBasisPoints: input.royalty.basis_points,
+    creators: input.creators,
+
+    editionNonce: input.supply.edition_nonce,
+    tokenStandard: TokenStandard.NonFungible,
+
+    collection: collection
+      ? { address: new PublicKey(collection.group_value), verified: false }
+      : null,
+
+    // TODO(jon): Read API doesn't return this info
+    collectionDetails: null,
+    // TODO(jon): Read API doesn't return this info
+    uses: null,
+  };
+};
+
+export class ReadApiConnection extends Connection {
+  constructor(
+    endpoint: string,
+    commitmentOrConfig?: Commitment | ConnectionConfig
+  ) {
+    // TODO(jon): Take in an optional override for the Read API, or potentially adapters for other endpoints
+    super(endpoint, commitmentOrConfig);
+  }
+
+  private callReadApi = async <ReadApiMethodParams, ReadApiJsonOutput>(
+    jsonRpcParams: JsonRpcParams<ReadApiMethodParams>
+  ): Promise<JsonRpcOutput<ReadApiJsonOutput>> => {
+    // Array-ify the params
+    const response = await fetch(this.rpcEndpoint, {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: jsonRpcParams.method,
+        id: jsonRpcParams.id,
+        params: jsonRpcParams.params,
+      }),
+    });
+
+    return await response.json();
+  };
+
+  // Asset id can be calculated via Bubblegum#getLeafAssetId
+  // It is a PDA with the following seeds: ["asset", tree, leafIndex]
+  async getAsset(assetId: PublicKey): Promise<GetAssetRpcResponse> {
+    const { result: asset } = await this.callReadApi<
+      GetAssetRpcInput,
+      GetAssetRpcResponse
+    >({
+      method: 'get_asset',
+      params: {
+        id: assetId.toBase58(),
+      },
+    });
+
+    console.info({ asset });
+    return asset;
+  }
+
+  // Asset id can be calculated via Bubblegum#getLeafAssetId
+  // It is a PDA with the following seeds: ["asset", tree, leafIndex]
+  async getAssetProof(assetId: PublicKey): Promise<GetAssetProofRpcResponse> {
+    const { result: proof } = await this.callReadApi<
+      GetAssetProofRpcInput,
+      GetAssetProofRpcResponse
+    >({
+      method: 'get_asset_proof',
+      params: {
+        id: assetId.toBase58(),
+      },
+    });
+
+    console.info({ proof });
+
+    return proof;
+  }
+}


### PR DESCRIPTION
there's a lot of gaps to cover, so i figured it'd be worth getting a spot-check on the structure of this support before going too much further. this PR includes:
- the base-level requirements for `metaplex.nfts().create({ tree: <insert-tree-address>})` to mint a compressed NFT into an initialized Merkle tree and into a collection. 
- a thin wrapper around implementations of the Metaplex Read API for `metaplex.nfts().findByAssetId`

open questions that would be valuable to answer:
1. should the Read API wrapper be in this package? or perhaps in a different sub-package?

known things that are missing that i want to add, provided there's good feedback on the approach so far:
1. The ability to `transfer` NFTs
3. More Read API methods like `findByCreator`, `findByOwner`
4. Helper functions for initializing trees
5. NFTs without collections
6. Tests

---
this package was tested with a script that looks roughly like:
```TypeScript
  const connection = new ReadApiConnection(<insert-RPC-URL>);
  const metaplex = Metaplex.make(connection).use(keypairIdentity(wallet));

  const { tree } = await createTree(metaplex);

  const response = await metaplex.nfts().create({
    uri,
    name: 'The first!',
    sellerFeeBasisPoints: 500,
    tree: new PublicKey('Diz7dzSm9tknCUMhHDJnbBzQRpQtFoNjaxykKtzR9JFA'),
    collection: new PublicKey('3DJYB7uaGf5BjZLBasNu1WVrZwT8bZyptQKSshFDMAU3'),
    collectionAuthority: wallet,
  });
```
here's [a sample transaction](https://explorer.solana.com/tx/5wq98AaM8XqSFZnhnbP1M8Dt34hs8MnEwWPsXGsASvWhkiEtmXJpgYAWu1fia7K6tCrDriqeKNa2wipZWdS8LedW) that this code ran
