### PR TITLE
add types to the exports field in package.json

### DIFF
--- a/.changeset/friendly-bananas-exercise.md
+++ b/.changeset/friendly-bananas-exercise.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/js': patch
+---
+
+Add types to exports in package.json

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -7,6 +7,7 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"
     }


### PR DESCRIPTION
Typescript 4.7+ with `moduleResolution: node16` reads the types from the exports field