### PR TITLE
Add missing optional field to JsonMetadata type

### DIFF
--- a/.changeset/nine-monkeys-share.md
+++ b/.changeset/nine-monkeys-share.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/js": patch
+---
+
+Add missing optional field to JsonMetadata type

--- a/packages/js/src/plugins/nftModule/models/JsonMetadata.ts
+++ b/packages/js/src/plugins/nftModule/models/JsonMetadata.ts
@@ -5,6 +5,7 @@ export type JsonMetadata<Uri = string> = {
   description?: string;
   seller_fee_basis_points?: number;
   image?: Uri;
+  animation_url?: Uri;
   external_url?: Uri;
   attributes?: Array<{
     trait_type?: string;


### PR DESCRIPTION
Added optional `animation_url` field outlined in the metadata standard. https://docs.metaplex.com/programs/token-metadata/token-standard

Issue discussed here:
https://github.com/metaplex-foundation/js/issues/500