### PR TITLE
fix: compression proof verification check

### DIFF
--- a/.changeset/thirty-panthers-peel.md
+++ b/.changeset/thirty-panthers-peel.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/js": patch
+---
+
+fix: compression proof verification check

--- a/packages/js/src/plugins/nftModule/operations/transferCompressedNft.ts
+++ b/packages/js/src/plugins/nftModule/operations/transferCompressedNft.ts
@@ -224,7 +224,7 @@ export const transferCompressedNftBuilder = (
 
   // check if the provided assetProof path is valid for the provided root
   if (
-    MerkleTree.verify(new PublicKey(compression.assetProof.root).toBuffer(), {
+    !MerkleTree.verify(new PublicKey(compression.assetProof.root).toBuffer(), {
       leafIndex: compression.data.leaf_id,
       leaf: new PublicKey(compression.assetProof.leaf).toBuffer(),
       root: new PublicKey(compression.assetProof.root).toBuffer(),


### PR DESCRIPTION
There is a bug that prevents compressed NFTs from actually being transferred via this SDK.

Currently: in the client side proof verification check, if the proof is valid it will always fail the client side check. If the proof is invalid, it will pass the client side check and fail on actual on chain checks.

Fix: correct the typo